### PR TITLE
Fix highlights when modified (parts of D-1 and D-2 tasks)

### DIFF
--- a/apps/frontend/src/components/form-context/TextField.tsx
+++ b/apps/frontend/src/components/form-context/TextField.tsx
@@ -3,8 +3,8 @@ import { cn } from "@/lib/utils";
 import { Input } from "../ui/input";
 import { Label } from "../ui/label";
 
+import { isFieldModified } from "./fields/useFieldModified";
 import { useFieldContext } from "./FormContext";
-import { deepEqual, getFieldDefaultValue } from "./fields/useFieldModified";
 
 export default function TextField({
   label,
@@ -18,7 +18,7 @@ export default function TextField({
   afterField?: React.ReactNode;
 }) {
   const field = useFieldContext<string>();
-  const isModified = !deepEqual(field.state.value, getFieldDefaultValue(field));
+  const isModified = isFieldModified(field);
 
   return (
     <Label

--- a/apps/frontend/src/components/form-context/fields/index.ts
+++ b/apps/frontend/src/components/form-context/fields/index.ts
@@ -10,4 +10,4 @@ export { ResearchProjectField } from "./ResearchProjectField";
 export { TagInput } from "./TagInput";
 export { TextValueArrayField } from "./TextValueArrayField";
 export { UrlArrayField } from "./UrlArrayField";
-export { useFieldModified } from "./useFieldModified";
+export { useFieldModified, isFieldModified } from "./useFieldModified";

--- a/apps/frontend/src/components/form-context/fields/useFieldModified.ts
+++ b/apps/frontend/src/components/form-context/fields/useFieldModified.ts
@@ -53,6 +53,28 @@ export function deepEqual(a: unknown, b: unknown): boolean {
   return [...keys].every((key) => deepEqual(objA[key], objB[key]));
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyFieldApi = any;
+
+/**
+ * Returns whether a field's current value differs from its default value.
+ * Pass an optional `key` to compare a single top-level property of the field
+ * value (e.g. "en" or "ja" for bilingual fields).
+ */
+export function isFieldModified(field: AnyFieldApi, key?: string): boolean {
+  const currentValue =
+    key != null
+      ? (field.state.value as Record<string, unknown>)?.[key]
+      : field.state.value;
+
+  const defaultValue =
+    key != null
+      ? (getFieldDefaultValue(field) as Record<string, unknown>)?.[key]
+      : getFieldDefaultValue(field);
+
+  return !deepEqual(currentValue, defaultValue);
+}
+
 /**
  * Returns whether a form field's current value differs from its initial value.
  *

--- a/apps/frontend/src/components/form-context/researchFields/BilingualTextField.tsx
+++ b/apps/frontend/src/components/form-context/researchFields/BilingualTextField.tsx
@@ -1,5 +1,5 @@
+import { isFieldModified } from "@/components/form-context/fields/useFieldModified";
 import { useFieldContext } from "@/components/form-context/FormContext";
-import { deepEqual, getFieldDefaultValue } from "@/components/form-context/fields/useFieldModified";
 import { Input } from "@/components/Input";
 import { TextareaAutosize } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
@@ -18,9 +18,8 @@ export default function BilingualTextField({
   variant?: "text" | "textarea";
 }) {
   const field = useFieldContext<BilingualText>();
-  const initial = getFieldDefaultValue(field) as BilingualText | undefined;
-  const isEnModified = !deepEqual(field.state.value.en, initial?.en);
-  const isJaModified = !deepEqual(field.state.value.ja, initial?.ja);
+  const isEnModified = isFieldModified(field, "en");
+  const isJaModified = isFieldModified(field, "ja");
 
   return (
     <Label className="flex w-full flex-col items-stretch gap-2">

--- a/apps/frontend/src/routes/{-$lang}/_layout/_authed/admin/-components/ContentItemDetails.tsx
+++ b/apps/frontend/src/routes/{-$lang}/_layout/_authed/admin/-components/ContentItemDetails.tsx
@@ -6,10 +6,12 @@ import {
   useSuspenseQuery,
 } from "@tanstack/react-query";
 import { Loader2, Pencil, Save } from "lucide-react";
-import { Suspense, useRef } from "react";
+import { Suspense, useRef, useState } from "react";
 
 import { Card } from "@/components/Card";
 import { useAppForm } from "@/components/form-context/FormContext";
+import { isFieldModified } from "@/components/form-context/fields/useFieldModified";
+import { ModifiedTag } from "@/components/form-context/fields/ModifiedTag";
 import { MarkdownClientPreview } from "@/components/markdown/MarkdownClientPreview";
 import { SkeletonLoading } from "@/components/Skeleton";
 import { Button } from "@/components/ui/button";
@@ -46,15 +48,15 @@ interface FormData {
   translation: ContentItem["translations"];
 }
 
-// use custom hook to suport resetting to not default values
 function useContentItemDetailsForm({
   initialValues,
+  setBaselineTranslation,
   id,
 }: {
   initialValues: FormData;
+  setBaselineTranslation: React.Dispatch<React.SetStateAction<FormData["translation"]>>;
   id: string;
 }) {
-  // const [defaultValues, setDefaultValues] = useState(initialValues);
 
   const { mutate: saveDraft } = useSaveDraft(id);
 
@@ -98,21 +100,18 @@ function useContentItemDetailsForm({
             const publishedContent =
               value.translation?.[value.lang]?.published?.content ?? "";
 
-            const resetValue = {
-              ...value,
-              translation: {
-                ...value.translation,
-                [value.lang]: {
-                  ...value.translation[value.lang],
-                  draft: {
-                    title: publishedTitle,
-                    content: publishedContent,
-                  },
+            const newTranslation = {
+              ...value.translation,
+              [value.lang]: {
+                ...value.translation[value.lang],
+                draft: {
+                  title: publishedTitle,
+                  content: publishedContent,
                 },
               },
             };
-            // setDefaultValues(resetValue);
-            formApi.reset(resetValue, { keepDefaultValues: true });
+            setBaselineTranslation(newTranslation);
+            formApi.reset({ ...value, translation: newTranslation });
           } finally {
             isIgnoreRef.current = false;
           }
@@ -134,21 +133,18 @@ function useContentItemDetailsForm({
           try {
             await publishDraft({ lang: value.lang });
 
-            const newValue = {
-              ...value,
-              translation: {
-                ...value.translation,
-                [value.lang]: {
-                  ...value.translation[value.lang],
-                  published: {
-                    title: title ?? "",
-                    content: content ?? "",
-                  },
+            const newTranslation = {
+              ...value.translation,
+              [value.lang]: {
+                ...value.translation[value.lang],
+                published: {
+                  title: title ?? "",
+                  content: content ?? "",
                 },
               },
             };
-
-            formApi.reset(newValue, { keepDefaultValues: true });
+            setBaselineTranslation(newTranslation);
+            formApi.reset({ ...value, translation: newTranslation });
           } finally {
             isIgnoreRef.current = false;
           }
@@ -176,11 +172,16 @@ export const ContentItemDetails = ({ id }: { id: string }) => {
   const { mutate: unpublishDraft, isPending: isUnpublishPending } =
     useUnpublishDraft(id);
 
+  const [baselineTranslation, setBaselineTranslation] = useState(
+    () => data.translations,
+  );
+
   const form = useContentItemDetailsForm({
     initialValues: {
       lang: i18n.defaultLocale,
-      translation: data.translations,
+      translation: baselineTranslation,
     },
+    setBaselineTranslation,
     id,
   });
 
@@ -333,9 +334,20 @@ export const ContentItemDetails = ({ id }: { id: string }) => {
                         onChangeDebounceMs: 800,
                       }}
                     >
-                      {(field) => (
-                        <field.ContentAreaField label="Content" assetFolder={id} />
-                      )}
+                      {(field) => {
+                        const isModified = isFieldModified(field);
+                        return (
+                          <field.ContentAreaField
+                            label={
+                              <span className="flex items-center gap-1">
+                                Content
+                                <ModifiedTag isModified={isModified} />
+                              </span>
+                            }
+                            assetFolder={id}
+                          />
+                        );
+                      }}
                     </form.AppField>
                   </Suspense>
                 </>

--- a/apps/frontend/src/routes/{-$lang}/_layout/_authed/admin/-components/DocumentVersion.tsx
+++ b/apps/frontend/src/routes/{-$lang}/_layout/_authed/admin/-components/DocumentVersion.tsx
@@ -10,6 +10,8 @@ import { Suspense, useEffect, useMemo, useRef, useState } from "react";
 
 import { Card } from "@/components/Card";
 import { useAppForm } from "@/components/form-context/FormContext";
+import { isFieldModified } from "@/components/form-context/fields/useFieldModified";
+import { ModifiedTag } from "@/components/form-context/fields/ModifiedTag";
 import { MarkdownClientPreview } from "@/components/markdown/MarkdownClientPreview";
 import { SkeletonLoading } from "@/components/Skeleton";
 import { Button } from "@/components/ui/button";
@@ -163,11 +165,16 @@ function DocumentVersionContent({
   const { mutate: unpublishVersion, isPending: isUnpublishPending } =
     useUnpublishVersion(contentId, versionNumber);
 
+  const [baselineTranslations, setBaselineTranslations] = useState(
+    () => selectedVersionContent?.translations ?? {},
+  );
+
   const form = useDocumentVersionForm({
     initialValues: {
       lang,
-      translations: selectedVersionContent?.translations ?? {},
+      translations: baselineTranslations,
     },
+    setBaselineTranslations,
     contentId,
     versionNumber,
   });
@@ -313,12 +320,20 @@ function DocumentVersionContent({
                     onChangeDebounceMs: 800,
                   }}
                 >
-                  {(field) => (
-                    <field.ContentAreaField
-                      label="Content"
-                      assetFolder={contentId}
-                    />
-                  )}
+                  {(field) => {
+                    const isModified = isFieldModified(field);
+                    return (
+                      <field.ContentAreaField
+                        label={
+                          <span className="flex items-center gap-1">
+                            Content
+                            <ModifiedTag isModified={isModified} />
+                          </span>
+                        }
+                        assetFolder={contentId}
+                      />
+                    );
+                  }}
                 </form.AppField>
               </Suspense>
             </>
@@ -369,10 +384,12 @@ function DocumentVersionContent({
 
 function useDocumentVersionForm({
   initialValues,
+  setBaselineTranslations,
   contentId,
   versionNumber,
 }: {
   initialValues: FormData;
+  setBaselineTranslations: React.Dispatch<React.SetStateAction<FormData["translations"]>>;
   contentId: string;
   versionNumber: number;
 }) {
@@ -415,20 +432,18 @@ function useDocumentVersionForm({
               const publishedContent =
                 value.translations?.[value.lang]?.published?.content ?? "";
 
-              const resetValue = {
-                ...value,
-                translations: {
-                  ...value.translations,
-                  [value.lang]: {
-                    ...value.translations[value.lang],
-                    draft: {
-                      title: publishedTitle,
-                      content: publishedContent,
-                    },
+              const newTranslations = {
+                ...value.translations,
+                [value.lang]: {
+                  ...value.translations[value.lang],
+                  draft: {
+                    title: publishedTitle,
+                    content: publishedContent,
                   },
                 },
               };
-              formApi.reset(resetValue, { keepDefaultValues: true });
+              setBaselineTranslations(newTranslations);
+              formApi.reset({ ...value, translations: newTranslations });
             })
             .finally(() => {
               isIgnoreRef.current = false;
@@ -450,20 +465,18 @@ function useDocumentVersionForm({
 
           publishDraft({ locale: value.lang })
             .then(() => {
-              const newValue = {
-                ...value,
-                translations: {
-                  ...value.translations,
-                  [value.lang]: {
-                    ...value.translations[value.lang],
-                    published: {
-                      title: title ?? "",
-                      content: content ?? "",
-                    },
+              const newTranslations = {
+                ...value.translations,
+                [value.lang]: {
+                  ...value.translations[value.lang],
+                  published: {
+                    title: title ?? "",
+                    content: content ?? "",
                   },
                 },
               };
-              formApi.reset(newValue, { keepDefaultValues: true });
+              setBaselineTranslations(newTranslations);
+              formApi.reset({ ...value, translations: newTranslations });
             })
             .finally(() => {
               isIgnoreRef.current = false;

--- a/apps/frontend/src/routes/{-$lang}/_layout/_authed/admin/-components/NewsItemContent.tsx
+++ b/apps/frontend/src/routes/{-$lang}/_layout/_authed/admin/-components/NewsItemContent.tsx
@@ -7,6 +7,7 @@ import { type Locale, useLocale } from "use-intl";
 import { Card } from "@/components/Card";
 import { useAppForm } from "@/components/form-context/FormContext";
 import { ModifiedTag } from "@/components/form-context/fields/ModifiedTag";
+import { isFieldModified } from "@/components/form-context/fields/useFieldModified";
 import { TabLabel } from "@/components/form-context/fields/TabLabel";
 import {
   Combobox,
@@ -382,20 +383,23 @@ function NewsItemForm({
       </div>
 
       <form.AppField name="tags">
-        {(field) => (
-          <div className="flex items-center gap-2">
-            <Label className="flex flex-col gap-2 items-stretch">
-              <span>Tags</span>
-              <TagPicker
-                allTags={allTags}
-                selectedTagIds={field.state.value}
-                onChange={field.handleChange}
-                onCreateTag={createTag}
-              />
-            </Label>
-            <ModifiedTag isModified={field.state.meta.isDirty} />
-          </div>
-        )}
+        {(field) => {
+          const isModified = isFieldModified(field);
+          return (
+            <div className="flex items-center gap-2">
+              <Label className="flex flex-col gap-2 items-stretch">
+                <span>Tags</span>
+                <TagPicker
+                  allTags={allTags}
+                  selectedTagIds={field.state.value}
+                  onChange={field.handleChange}
+                  onCreateTag={createTag}
+                />
+              </Label>
+              <ModifiedTag isModified={isModified} />
+            </div>
+          );
+        }}
       </form.AppField>
 
       {/* Item-level fields */}
@@ -491,7 +495,7 @@ function NewsItemForm({
             </form.AppField>
             <form.AppField name={`translations.${loc}.content`}>
               {(field) => {
-                const isDirty = field.state.meta.isDirty;
+                const isDirty = isFieldModified(field);
                 return (
                   <Suspense fallback={<div>Loading...</div>}>
                     <field.ContentAreaField


### PR DESCRIPTION
Make fixes to highlight when modified (part of D-1 and D-2):
- Add a new `isFieldModified` utility to check modifications to fields that unifies previous existing check methods (kept useFieldModified in case it might have a use in the future)
- Fix title highlight being reset by auto-save for both Content and Documents pages
- Add the existing `ModifiedTag` from News page to both Content and Documents pages Content fields