### PR TITLE
Fix filter panel height (issue A-1)

### DIFF
--- a/apps/frontend/src/components/FilterableCard.tsx
+++ b/apps/frontend/src/components/FilterableCard.tsx
@@ -32,7 +32,10 @@ export function FilterableCard({
         isOpen: panelOpen,
       })}
       captionSize={captionSize}
-      containerClassName="relative overflow-hidden flex flex-col flex-1"
+      containerClassName={cn(
+        "relative overflow-x-clip flex flex-col flex-1",
+        panelOpen && "min-h-screen",
+      )}
     >
       <Suspense fallback={<SkeletonLoading />}>
         {renderChildren({ panelOpen })}
@@ -40,7 +43,7 @@ export function FilterableCard({
 
       <div
         className={cn(
-          "absolute inset-y-0 right-0 z-10 min-w-96 overflow-y-auto border-l border-l-primary-translucent bg-white shadow-lg",
+          "absolute top-0 right-0 z-10 min-w-96 max-h-full overflow-y-auto border-l border-l-primary-translucent bg-white shadow-lg",
           "transition-transform duration-300 ease-in-out",
           panelOpen ? "translate-x-0" : "translate-x-full",
         )}


### PR DESCRIPTION
Fix for A-1:
- Use minimal CSS fix to make the filter panel height at least as tall as the viewport even when the table has few results

@neznayer Tried to make the fix as simple as possible but tell me if it is better to make deeper changes to the filter panel