### PR TITLE
Add results count to research list page table (A-1)

### DIFF
--- a/apps/frontend/localization/messages/en.json
+++ b/apps/frontend/localization/messages/en.json
@@ -154,7 +154,8 @@
     "datePublished": "Date published",
     "dateModified": "Date modified",
     "versionReleaseDate": "Version release date",
-    "releaseNote": "Release note"
+    "releaseNote": "Release note",
+    "totalResults": "{count} results"
   },
   "DatasetVersionCard": {
     "releaseInfo": "Release info",

--- a/apps/frontend/localization/messages/ja.json
+++ b/apps/frontend/localization/messages/ja.json
@@ -154,7 +154,8 @@
     "datePublished": "公開日",
     "dateModified": "更新日",
     "versionReleaseDate": "バージョン公開日",
-    "releaseNote": "リリースノート"
+    "releaseNote": "リリースノート",
+    "totalResults": "全{count}件"
   },
   "DatasetVersionCard": {
     "releaseInfo": "リリース情報",

--- a/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/data-use/research/index.tsx
+++ b/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/data-use/research/index.tsx
@@ -198,9 +198,12 @@ function CardContent({ panelOpen }: { panelOpen: boolean }) {
   return (
     <>
       <div className="overflow-x-auto flex flex-col flex-1 relative">
+        <p className="text-sm text-muted-foreground">
+          {t("totalResults", { count: researchesData.meta.pagination.total })}
+        </p>
         <Table
           className={cn(
-            "mt-4 text-sm flex-1 transition-[margin] z-10 relative",
+            "mt-2 text-sm flex-1 transition-[margin] z-10 relative",
             {
               "mr-filter-panel": panelOpen,
             },


### PR DESCRIPTION
Fix for A-1:
- Add results count at the top left of the research list page table
- Add related dictionary entries

@neznayer Should I also add the same count to the Dataset list page?