### PR TITLE
Order dataset list cell by alphabetical (A-1)

### DIFF
--- a/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/data-use/research/index.tsx
+++ b/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/data-use/research/index.tsx
@@ -243,17 +243,24 @@ const columns = [
     cell: (ctx) => {
       return (
         <CollapsiblePreview
-          items={ctx.row.original.datasetIds.map((id) => ({
-            id,
-            content: () => (
-              <Route.Link
-                to="../datasets/$datasetId"
-                params={{ datasetId: id }}
-              >
-                <TextWithIcon icon={FA_ICONS.dataset}>{id}</TextWithIcon>
-              </Route.Link>
-            ),
-          }))}
+          items={[...ctx.row.original.datasetIds]
+            .sort((a, b) =>
+              a.localeCompare(b, undefined, {
+                sensitivity: "base",
+                numeric: true,
+              }),
+            )
+            .map((id) => ({
+              id,
+              content: () => (
+                <Route.Link
+                  to="../datasets/$datasetId"
+                  params={{ datasetId: id }}
+                >
+                  <TextWithIcon icon={FA_ICONS.dataset}>{id}</TextWithIcon>
+                </Route.Link>
+              ),
+            }))}
         />
       );
     },


### PR DESCRIPTION
Fix for A-1:
- Add a custom sort in Datasets ID cell to order by alphabetical (and numerical)