### PR TITLE
Fix for 51. change cart behavior when logged out

### DIFF
--- a/apps/frontend/localization/messages/en.json
+++ b/apps/frontend/localization/messages/en.json
@@ -101,6 +101,7 @@
     "dataset-list": "Dataset list",
     "already-in-cart": "Already in cart",
     "add-to-cart": "Add to cart",
+    "login-to-add": "Login and add to cart",
     "version": "Version",
     "releaseDate": "Release date",
     "typeOfData": "Type of data",

--- a/apps/frontend/localization/messages/ja.json
+++ b/apps/frontend/localization/messages/ja.json
@@ -101,6 +101,7 @@
     "dataset-list": "データセット一覧",
     "already-in-cart": "カートに追加済み",
     "add-to-cart": "カートに追加",
+    "login-to-add": "ログインしてカートに追加",
     "version": "バージョン",
     "releaseDate": "公開日付",
     "typeOfData": "データの種類",

--- a/apps/frontend/src/components/Navbar.tsx
+++ b/apps/frontend/src/components/Navbar.tsx
@@ -2,6 +2,7 @@ import {
   useLocation,
   useNavigate,
   useRouteContext,
+  useRouter,
 } from "@tanstack/react-router";
 import {
   ChevronsRight,
@@ -38,7 +39,6 @@ import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
 export function Navbar() {
   const tCommon = useTranslations("common");
 
-  const { user } = useRouteContext({ from: "__root__" });
   const { lang, siteNavigation } = useRouteContext({
     from: "/{-$lang}/_layout",
   });
@@ -160,7 +160,7 @@ export function Navbar() {
       <div className="flex items-center gap-1 md:gap-2">
         <LangSwitcher />
         <Search />
-        {user ? <ShoppingCartButton /> : null}
+        <ShoppingCartButton />
         <UserMenu />
       </div>
     </header>
@@ -377,15 +377,33 @@ function UserMenu() {
 
 function ShoppingCartButton() {
   const { cart } = useCart();
+  const { user } = useRouteContext({ from: "__root__" });
   const { lang } = useRouteContext({ from: "/{-$lang}/_layout" });
-  const navigate = useNavigate({ from: "/{-$lang}" });
+  const navigate = useNavigate();
+  const router = useRouter();
+
+  function handleClick() {
+    if (!user) {
+      const cartHref = router.buildLocation({
+        to: "/{-$lang}/cart",
+        params: { lang },
+      }).href;
+      void navigate({
+        to: "/auth/login",
+        search: { redirect: cartHref },
+        reloadDocument: true,
+      });
+    } else {
+      void navigate({ to: "/{-$lang}/cart", params: { lang } });
+    }
+  }
 
   return (
     <Button
       variant={"plain"}
       className="relative"
       size="icon"
-      onClick={() => navigate({ to: "/{-$lang}/cart", params: { lang } })}
+      onClick={handleClick}
     >
       {cart.length > 0 ? (
         <span className="bg-accent absolute top-0 left-0 text-xs text-white rounded-full min-w-8 w-fit p-0.5">

--- a/apps/frontend/src/hooks/useCart.tsx
+++ b/apps/frontend/src/hooks/useCart.tsx
@@ -1,6 +1,10 @@
 import { type DatasetDoc } from "@humandbs/backend/types";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useRouteContext } from "@tanstack/react-router";
+import {
+  useNavigate,
+  useRouteContext,
+  useSearch,
+} from "@tanstack/react-router";
 import { useEffect } from "react";
 
 const keyFor = (userId: string | undefined) => `cart:${userId}`;
@@ -27,30 +31,45 @@ export function useCart() {
 
   const setCart = (updater: (prev: CartItem[]) => CartItem[]) => {
     queryClient.setQueryData<CartItem[]>(["cart", user?.id], (prev) =>
-      updater(prev ?? [])
+      updater(prev ?? []),
     );
   };
 
   return {
     cart,
-    add(dataset: CartItem) {
+    add: (dataset: CartItem) => {
       setCart((prev) =>
         prev.some((item) => item.datasetId === dataset.datasetId)
           ? prev
-          : [...prev, dataset]
+          : [...prev, dataset],
       );
     },
-    remove(dataset: CartItem) {
+    remove: (dataset: CartItem) => {
       setCart((prev) =>
-        prev.filter((item) => {
-          const filter = item.datasetId !== dataset.datasetId;
-
-          return filter;
-        })
+        prev.filter((item) => item.datasetId !== dataset.datasetId),
       );
     },
-    clear() {
+    clear: () => {
       setCart(() => []);
     },
   };
+}
+
+export function useAutoAddToCart(data: DatasetDoc) {
+  const { user } = useRouteContext({ from: "__root__" });
+  const navigate = useNavigate({
+    from: "/{-$lang}/data-use/datasets/$datasetId",
+  });
+  const { add } = useCart();
+  const { addToCart } = useSearch({ strict: false });
+
+  useEffect(() => {
+    if (!addToCart || !user) return;
+    add(data);
+    void navigate({
+      to: ".",
+      search: (prev) => ({ ...prev, addToCart: undefined }),
+      replace: true,
+    });
+  }, [addToCart, user?.id]);
 }

--- a/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/data-use/datasets/$datasetId/$version.tsx
+++ b/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/data-use/datasets/$datasetId/$version.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 
+import { useAutoAddToCart } from "@/hooks/useCart";
 import { getDatasetQueryOptions } from "@/serverFunctions/datasets";
 
 import { DatasetVersionCard } from "./-DatasetVersionCard";
@@ -24,6 +25,8 @@ export const Route = createFileRoute(
 
 function RouteComponent() {
   const { data } = Route.useLoaderData();
+
+  useAutoAddToCart(data);
 
   return <DatasetVersionCard versionData={data} />;
 }

--- a/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/data-use/datasets/$datasetId/-DatasetVersionCard.tsx
+++ b/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/data-use/datasets/$datasetId/-DatasetVersionCard.tsx
@@ -1,5 +1,9 @@
 import { type DatasetDoc } from "@humandbs/backend/types";
-import { useRouteContext } from "@tanstack/react-router";
+import {
+  useLocation,
+  useNavigate,
+  useRouteContext,
+} from "@tanstack/react-router";
 import { useLocale, useTranslations } from "use-intl";
 
 import { CardWithCaption } from "@/components/Card";
@@ -43,11 +47,28 @@ export function DatasetVersionCard({
     [t("criteria")]: versionData.criteria,
   };
 
+  const navigate = useNavigate();
+  const currentLocation = useLocation();
+
   const { add, cart } = useCart();
 
   const isInCart = cart.some(
     (item) => item.datasetId === versionData.datasetId,
   );
+
+  const handleAddToCart = () => {
+    if (!user) {
+      void navigate({
+        to: "/auth/login",
+        search: {
+          redirect: `${currentLocation.href}${currentLocation.searchStr ? "&" : "?"}addToCart=${versionData.datasetId}`,
+        },
+        reloadDocument: true,
+      });
+      return;
+    }
+    add(versionData as DatasetDoc);
+  };
 
   const identifier =
     [versionData.datasetId, versionData.version].filter(Boolean).join(".") ||
@@ -75,17 +96,19 @@ export function DatasetVersionCard({
               ) : null
             }
             right={
-              showPublicActions && user ? (
+              showPublicActions ? (
                 <div className="flex gap-5">
                   <Button
                     variant={"accent"}
                     className="rounded-full"
-                    disabled={isInCart}
-                    onClick={() => {
-                      add(versionData as DatasetDoc);
-                    }}
+                    disabled={!!user && isInCart}
+                    onClick={handleAddToCart}
                   >
-                    {isInCart ? t("already-in-cart") : t("add-to-cart")}
+                    {user
+                      ? isInCart
+                        ? t("already-in-cart")
+                        : t("add-to-cart")
+                      : t("login-to-add")}
                   </Button>
                 </div>
               ) : null

--- a/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/data-use/datasets/$datasetId/index.tsx
+++ b/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/data-use/datasets/$datasetId/index.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 
+import { useAutoAddToCart } from "@/hooks/useCart";
 import { getDatasetQueryOptions } from "@/serverFunctions/datasets";
 
 import { DatasetVersionCard } from "./-DatasetVersionCard";
@@ -26,6 +27,8 @@ export const Route = createFileRoute(
 
 function RouteComponent() {
   const { data } = Route.useLoaderData();
+
+  useAutoAddToCart(data);
 
   return <DatasetVersionCard versionData={data} />;
 }

--- a/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/data-use/datasets/$datasetId/route.tsx
+++ b/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/data-use/datasets/$datasetId/route.tsx
@@ -1,8 +1,10 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
 
 export const Route = createFileRoute(
   "/{-$lang}/_layout/_main/_other/data-use/datasets/$datasetId"
 )({
+  validateSearch: z.object({ addToCart: z.string().optional() }),
   loader: ({ params }) => {
     return {
       crumb: params.datasetId,


### PR DESCRIPTION
Fixes for 51.:
- Show add to cart button when logged out, with a redirect to login page (and add dataset to cart afterwards)
- Add related entries to dictionaries
- Show cart button on navbar when logged out, with a redirect to login page
