### PR TITLE
Fix for 43. show date modified on dataset page

### DIFF
--- a/apps/frontend/localization/messages/en.json
+++ b/apps/frontend/localization/messages/en.json
@@ -104,6 +104,7 @@
     "login-to-add": "Login and add to cart",
     "version": "Version",
     "releaseDate": "Release date",
+    "date-modified": "Date modified",
     "typeOfData": "Type of data",
     "criteria": "Access type",
     "experiments": "Experiments",

--- a/apps/frontend/localization/messages/ja.json
+++ b/apps/frontend/localization/messages/ja.json
@@ -104,6 +104,7 @@
     "login-to-add": "ログインしてカートに追加",
     "version": "バージョン",
     "releaseDate": "公開日付",
+    "date-modified": "更新日",
     "typeOfData": "データの種類",
     "criteria": "アクセス制限",
     "experiments": "実験一覧",

--- a/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/data-use/datasets/$datasetId/-DatasetVersionCard.tsx
+++ b/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/data-use/datasets/$datasetId/-DatasetVersionCard.tsx
@@ -120,7 +120,7 @@ export function DatasetVersionCard({
       }
     >
       <section>
-        <dl className="columns-2">
+        <dl className="columns-2 mb-7">
           <div className="break-inside-avoid-column">
             <KeyValueCard title={t("releaseDate")}>
               <div>
@@ -138,6 +138,10 @@ export function DatasetVersionCard({
             </KeyValueCard>
             <Separator show variant={"solid"} />
           </div>
+
+          <KeyValueCard title={t("date-modified")}>
+            <p>{versionData.releaseDate}</p>
+          </KeyValueCard>
 
           <div className="break-inside-avoid-column">
             <KeyValueCard


### PR DESCRIPTION
Fix for ticket 43:
- Use `versionData.releaseDate` to use as a replacement for `dateModified` on the dataset page
- Add the related entries to dictionaries