### PR TITLE
style(frontend): 研究・データセット切り替えUIをパンくず右上の台形タブに刷新

### DIFF
--- a/apps/frontend/src/components/ResearchDatasetTabs.tsx
+++ b/apps/frontend/src/components/ResearchDatasetTabs.tsx
@@ -1,0 +1,119 @@
+import { Link, useLocation } from "@tanstack/react-router";
+import { useTranslations } from "use-intl";
+
+import { cn } from "@/lib/utils";
+import { cleanEmptyParams } from "@/utils/cleanEmptyParams";
+
+const researchSorts = new Set([
+  "humId",
+  "title",
+  "releaseDate",
+  "datePublished",
+  "dateModified",
+  "relevance",
+]);
+const datasetSorts = new Set(["datasetId", "releaseDate", "relevance"]);
+
+function isStringInSet(value: unknown, set: Set<string>): value is string {
+  return typeof value === "string" && set.has(value);
+}
+
+function buildTableSwitchSearch(
+  currentSearch: Record<string, unknown>,
+  target: "dataset" | "research",
+) {
+  if (target === "research") {
+    return {
+      page: 1,
+      limit: currentSearch.limit,
+      sort: isStringInSet(currentSearch.sort, researchSorts) ? currentSearch.sort : undefined,
+      order: currentSearch.order,
+      query: currentSearch.query,
+      datePublished: currentSearch.datePublished,
+      dateModified: currentSearch.dateModified,
+      datasetFilters: currentSearch.datasetFilters ?? currentSearch.filters,
+    };
+  }
+
+  return {
+    page: 1,
+    limit: currentSearch.limit,
+    sort: isStringInSet(currentSearch.sort, datasetSorts) ? currentSearch.sort : undefined,
+    order: currentSearch.order,
+    query: currentSearch.query,
+    humId: currentSearch.humId,
+    filters: currentSearch.filters ?? currentSearch.datasetFilters,
+  };
+}
+
+function getTableSwitchSearch(currentSearch: Record<string, unknown>) {
+  return {
+    research: cleanEmptyParams(buildTableSwitchSearch(currentSearch, "research")),
+    dataset: cleanEmptyParams(buildTableSwitchSearch(currentSearch, "dataset")),
+  };
+}
+
+export function ResearchDatasetTabs() {
+  const tCommon = useTranslations("common");
+  const location = useLocation();
+
+  const pathname = location.pathname;
+  const isResearch = pathname.includes("/research");
+  const isDataset = pathname.includes("/dataset");
+
+  if (!isResearch && !isDataset) return null;
+
+  const currentPlace: "research" | "dataset" = isResearch ? "research" : "dataset";
+  const switchSearch = getTableSwitchSearch(location.search as Record<string, unknown>);
+
+  // スタイルの共通定義（左が斜め、右が垂直の台形タブ）
+  const baseTabClass =
+    "relative px-8 flex items-end pb-1 border-t border-r border-gray-200 transition-all duration-200 cursor-pointer font-bold text-sm select-none rounded-tr-md no-underline";
+  const skewBeforeClass =
+    "before:content-[''] before:absolute before:top-[-1px] before:bottom-0 before:left-[-14px] before:w-[14px] before:border-t before:border-l before:border-gray-200 before:rounded-tl-md before:skew-x-[-25deg] before:origin-bottom-right before:transition-all before:duration-200";
+
+  // Active / Inactive 用のクラス
+  const activeClass =
+    "h-[30px] bg-white text-secondary z-10 border-b border-b-white before:bg-white before:border-b before:border-b-white shadow-[0_-2px_3px_rgba(0,0,0,0.02)]";
+  const inactiveClass =
+    "h-[29px] -translate-y-[1px] bg-gray-100/90 text-muted-foreground hover:bg-gray-50 hover:before:bg-gray-50 z-0 border-b border-b-gray-200 before:bg-gray-100/90 before:border-b before:border-b-gray-200 shadow-[inset_0_-3px_5px_-1px_rgba(0,0,0,0.06)] before:shadow-[inset_0_-3px_5px_-1px_rgba(0,0,0,0.06)]";
+
+  return (
+    <div className="flex items-end pl-6 mr-[-1px]">
+      {/* 研究タブ */}
+      <Link
+        to="/{-$lang}/research"
+        search={switchSearch.research}
+        className={cn(
+          baseTabClass,
+          skewBeforeClass,
+          currentPlace === "research" ? activeClass : inactiveClass,
+        )}
+      >
+        <span
+          className={cn("inline-block", currentPlace === "research" ? "" : "translate-y-[1px]")}
+        >
+          {tCommon("research")}
+        </span>
+      </Link>
+
+      {/* データセットタブ */}
+      <Link
+        to="/{-$lang}/dataset"
+        search={switchSearch.dataset}
+        className={cn(
+          baseTabClass,
+          skewBeforeClass,
+          "-ml-1.5", // タブの重なり
+          currentPlace === "dataset" ? activeClass : inactiveClass,
+        )}
+      >
+        <span
+          className={cn("inline-block", currentPlace === "dataset" ? "" : "translate-y-[1px]")}
+        >
+          {tCommon("dataset")}
+        </span>
+      </Link>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/ResearchDatasetTabs.tsx
+++ b/apps/frontend/src/components/ResearchDatasetTabs.tsx
@@ -66,13 +66,11 @@ export function ResearchDatasetTabs() {
   const currentPlace: "research" | "dataset" = isResearch ? "research" : "dataset";
   const switchSearch = getTableSwitchSearch(location.search as Record<string, unknown>);
 
-  // スタイルの共通定義（左が斜め、右が垂直の台形タブ）
   const baseTabClass =
-    "relative px-8 flex items-end pb-1 border-t border-r border-gray-200 transition-all duration-200 cursor-pointer font-bold text-sm select-none rounded-tr-md no-underline";
+    "relative px-8 flex items-end pb-1 border-t border-r border-gray-200 cursor-pointer font-bold text-sm select-none rounded-tr-md no-underline";
   const skewBeforeClass =
-    "before:content-[''] before:absolute before:top-[-1px] before:bottom-0 before:left-[-14px] before:w-[14px] before:border-t before:border-l before:border-gray-200 before:rounded-tl-md before:skew-x-[-25deg] before:origin-bottom-right before:transition-all before:duration-200";
+    "before:content-[''] before:absolute before:top-[-1px] before:bottom-0 before:left-[-14px] before:w-[14px] before:border-t before:border-l before:border-gray-200 before:rounded-tl-md before:skew-x-[-25deg] before:origin-bottom-right";
 
-  // Active / Inactive 用のクラス
   const activeClass =
     "h-[30px] bg-white text-secondary z-10 border-b border-b-white before:bg-white before:border-b before:border-b-white shadow-[0_-2px_3px_rgba(0,0,0,0.02)]";
   const inactiveClass =
@@ -81,7 +79,7 @@ export function ResearchDatasetTabs() {
   return (
     <nav
       aria-label={`${tCommon("research")} / ${tCommon("dataset")}`}
-      className="flex items-end pl-6 mr-[-1px]"
+      className="flex items-end pl-6 mr-[-1px] -mt-[5px]"
     >
       {/* 研究タブ */}
       <Link
@@ -109,7 +107,7 @@ export function ResearchDatasetTabs() {
         className={cn(
           baseTabClass,
           skewBeforeClass,
-          "-ml-1.5", // タブの重なり
+          "-ml-1.5",
           currentPlace === "dataset" ? activeClass : inactiveClass,
         )}
       >

--- a/apps/frontend/src/components/ResearchDatasetTabs.tsx
+++ b/apps/frontend/src/components/ResearchDatasetTabs.tsx
@@ -1,4 +1,5 @@
 import { Link, useLocation } from "@tanstack/react-router";
+import { cva } from "class-variance-authority";
 import { useTranslations } from "use-intl";
 
 import { cn } from "@/lib/utils";
@@ -53,6 +54,35 @@ function getTableSwitchSearch(currentSearch: Record<string, unknown>) {
   };
 }
 
+const tab = cva(
+  [
+    "relative flex cursor-pointer select-none items-end px-8 pb-1",
+    "rounded-tr-md font-bold text-sm no-underline",
+    "border-gray-200 border-t border-r",
+    "before:absolute before:-top-px before:bottom-0 before:left-[-14px] before:w-[14px]",
+    "before:border-gray-200 before:border-t before:border-l",
+    "before:origin-bottom-right before:skew-x-[-25deg] before:rounded-tl-md",
+  ],
+  {
+    variants: {
+      active: {
+        true: [
+          "z-10 h-[30px] bg-white text-secondary",
+          "border-b border-b-white shadow-[0_-2px_3px_rgba(0,0,0,0.02)]",
+          "before:border-b before:border-b-white before:bg-white",
+        ],
+        false: [
+          "z-0 h-[29px] -translate-y-px bg-gray-100/90 text-muted-foreground",
+          "border-b border-b-gray-200 shadow-[inset_0_-3px_5px_-1px_rgba(0,0,0,0.06)]",
+          "hover:bg-gray-50 hover:before:bg-gray-50",
+          "before:border-b before:border-b-gray-200 before:bg-gray-100/90",
+          "before:shadow-[inset_0_-3px_5px_-1px_rgba(0,0,0,0.06)]",
+        ],
+      },
+    },
+  },
+);
+
 export function ResearchDatasetTabs() {
   const tCommon = useTranslations("common");
   const location = useLocation();
@@ -66,35 +96,18 @@ export function ResearchDatasetTabs() {
   const currentPlace: "research" | "dataset" = isResearch ? "research" : "dataset";
   const switchSearch = getTableSwitchSearch(location.search as Record<string, unknown>);
 
-  const baseTabClass =
-    "relative px-8 flex items-end pb-1 border-t border-r border-gray-200 cursor-pointer font-bold text-sm select-none rounded-tr-md no-underline";
-  const skewBeforeClass =
-    "before:content-[''] before:absolute before:top-[-1px] before:bottom-0 before:left-[-14px] before:w-[14px] before:border-t before:border-l before:border-gray-200 before:rounded-tl-md before:skew-x-[-25deg] before:origin-bottom-right";
-
-  const activeClass =
-    "h-[30px] bg-white text-secondary z-10 border-b border-b-white before:bg-white before:border-b before:border-b-white shadow-[0_-2px_3px_rgba(0,0,0,0.02)]";
-  const inactiveClass =
-    "h-[29px] -translate-y-[1px] bg-gray-100/90 text-muted-foreground hover:bg-gray-50 hover:before:bg-gray-50 z-0 border-b border-b-gray-200 before:bg-gray-100/90 before:border-b before:border-b-gray-200 shadow-[inset_0_-3px_5px_-1px_rgba(0,0,0,0.06)] before:shadow-[inset_0_-3px_5px_-1px_rgba(0,0,0,0.06)]";
-
   return (
     <nav
       aria-label={`${tCommon("research")} / ${tCommon("dataset")}`}
-      className="flex items-end pl-6 mr-[-1px] -mt-[5px]"
+      className="-mt-[5px] -mr-px flex items-end pl-6"
     >
       {/* 研究タブ */}
       <Link
         to="/{-$lang}/research"
         search={switchSearch.research}
-        aria-current={currentPlace === "research" ? "page" : undefined}
-        className={cn(
-          baseTabClass,
-          skewBeforeClass,
-          currentPlace === "research" ? activeClass : inactiveClass,
-        )}
+        className={tab({ active: currentPlace === "research" })}
       >
-        <span
-          className={cn("inline-block", currentPlace === "research" ? "" : "translate-y-[1px]")}
-        >
+        <span className={cn("inline-block", { "translate-y-px": currentPlace === "research" })}>
           {tCommon("research")}
         </span>
       </Link>
@@ -103,17 +116,9 @@ export function ResearchDatasetTabs() {
       <Link
         to="/{-$lang}/dataset"
         search={switchSearch.dataset}
-        aria-current={currentPlace === "dataset" ? "page" : undefined}
-        className={cn(
-          baseTabClass,
-          skewBeforeClass,
-          "-ml-1.5",
-          currentPlace === "dataset" ? activeClass : inactiveClass,
-        )}
+        className={cn("-ml-1.5", tab({ active: currentPlace === "dataset" }))}
       >
-        <span
-          className={cn("inline-block", currentPlace === "dataset" ? "" : "translate-y-[1px]")}
-        >
+        <span className={cn("inline-block", { "translate-y-px": currentPlace === "dataset" })}>
           {tCommon("dataset")}
         </span>
       </Link>

--- a/apps/frontend/src/components/ResearchDatasetTabs.tsx
+++ b/apps/frontend/src/components/ResearchDatasetTabs.tsx
@@ -79,11 +79,15 @@ export function ResearchDatasetTabs() {
     "h-[29px] -translate-y-[1px] bg-gray-100/90 text-muted-foreground hover:bg-gray-50 hover:before:bg-gray-50 z-0 border-b border-b-gray-200 before:bg-gray-100/90 before:border-b before:border-b-gray-200 shadow-[inset_0_-3px_5px_-1px_rgba(0,0,0,0.06)] before:shadow-[inset_0_-3px_5px_-1px_rgba(0,0,0,0.06)]";
 
   return (
-    <div className="flex items-end pl-6 mr-[-1px]">
+    <nav
+      aria-label={`${tCommon("research")} / ${tCommon("dataset")}`}
+      className="flex items-end pl-6 mr-[-1px]"
+    >
       {/* 研究タブ */}
       <Link
         to="/{-$lang}/research"
         search={switchSearch.research}
+        aria-current={currentPlace === "research" ? "page" : undefined}
         className={cn(
           baseTabClass,
           skewBeforeClass,
@@ -101,6 +105,7 @@ export function ResearchDatasetTabs() {
       <Link
         to="/{-$lang}/dataset"
         search={switchSearch.dataset}
+        aria-current={currentPlace === "dataset" ? "page" : undefined}
         className={cn(
           baseTabClass,
           skewBeforeClass,
@@ -114,6 +119,6 @@ export function ResearchDatasetTabs() {
           {tCommon("dataset")}
         </span>
       </Link>
-    </div>
+    </nav>
   );
 }

--- a/apps/frontend/src/components/SearchCaption.tsx
+++ b/apps/frontend/src/components/SearchCaption.tsx
@@ -1,4 +1,3 @@
-import { Link, useLocation } from "@tanstack/react-router";
 import { Filter, Search, X } from "lucide-react";
 import { useTranslations } from "use-intl";
 
@@ -6,9 +5,7 @@ import { startTransition, useEffect, useState } from "react";
 
 import { Input } from "@/components/Input";
 import { Button } from "@/components/ui/button";
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { cn } from "@/lib/utils";
-import { cleanEmptyParams } from "@/utils/cleanEmptyParams";
 
 export function SearchCaption({
   title,
@@ -57,13 +54,6 @@ export function SearchCaption({
     });
   }
 
-  const location = useLocation();
-
-  const place = location.pathname.split("/").at(-1) as "dataset" | "research";
-  const switchSearch = getTableSwitchSearch(location.search as Record<string, unknown>);
-
-  const tCommon = useTranslations("common");
-
   return (
     <div className="flex h-fit flex-wrap items-center justify-between">
       <div className="flex items-baseline gap-10">
@@ -74,28 +64,6 @@ export function SearchCaption({
       </div>
 
       <div className="flex flex-wrap items-center gap-4">
-        <ToggleGroup variant="pill" type="single" value={place} className="border border-gray-200">
-          <ToggleGroupItem
-            asChild
-            value="research"
-            variant="pill"
-            className="px-8 data-[state=on]:bg-accent"
-          >
-            <Link className="no-underline" to="/{-$lang}/research" search={switchSearch.research}>
-              {tCommon("research")}
-            </Link>
-          </ToggleGroupItem>
-          <ToggleGroupItem
-            asChild
-            value="dataset"
-            variant="pill"
-            className="px-8 data-[state=on]:bg-secondary"
-          >
-            <Link className="no-underline" to="/{-$lang}/dataset" search={switchSearch.dataset}>
-              {tCommon("dataset")}
-            </Link>
-          </ToggleGroupItem>
-        </ToggleGroup>
         <div className="flex gap-1">
           <Button variant={"tableAction"} className="h-fit" size={"tableAction"} onClick={onCopy}>
             {t("copy")}
@@ -172,51 +140,4 @@ export function SearchCaption({
   );
 }
 
-const researchSorts = new Set([
-  "humId",
-  "title",
-  "releaseDate",
-  "datePublished",
-  "dateModified",
-  "relevance",
-]);
-const datasetSorts = new Set(["datasetId", "releaseDate", "relevance"]);
 
-function getTableSwitchSearch(currentSearch: Record<string, unknown>) {
-  return {
-    research: cleanEmptyParams(buildTableSwitchSearch(currentSearch, "research")),
-    dataset: cleanEmptyParams(buildTableSwitchSearch(currentSearch, "dataset")),
-  };
-}
-
-function buildTableSwitchSearch(
-  currentSearch: Record<string, unknown>,
-  target: "dataset" | "research",
-) {
-  if (target === "research") {
-    return {
-      page: 1,
-      limit: currentSearch.limit,
-      sort: isStringInSet(currentSearch.sort, researchSorts) ? currentSearch.sort : undefined,
-      order: currentSearch.order,
-      query: currentSearch.query,
-      datePublished: currentSearch.datePublished,
-      dateModified: currentSearch.dateModified,
-      datasetFilters: currentSearch.datasetFilters ?? currentSearch.filters,
-    };
-  }
-
-  return {
-    page: 1,
-    limit: currentSearch.limit,
-    sort: isStringInSet(currentSearch.sort, datasetSorts) ? currentSearch.sort : undefined,
-    order: currentSearch.order,
-    query: currentSearch.query,
-    humId: currentSearch.humId,
-    filters: currentSearch.filters ?? currentSearch.datasetFilters,
-  };
-}
-
-function isStringInSet(value: unknown, set: Set<string>): value is string {
-  return typeof value === "string" && set.has(value);
-}

--- a/apps/frontend/src/routes/{-$lang}/_layout/_main/_other.tsx
+++ b/apps/frontend/src/routes/{-$lang}/_layout/_main/_other.tsx
@@ -1,23 +1,35 @@
-import { createFileRoute, Outlet } from "@tanstack/react-router";
+import { createFileRoute, Outlet, useLocation } from "@tanstack/react-router";
 
 import { Breadcrumbs } from "@/components/Breadcrumb";
 import { Card } from "@/components/Card";
+import { ResearchDatasetTabs } from "@/components/ResearchDatasetTabs";
 
 export const Route = createFileRoute("/{-$lang}/_layout/_main/_other")({
   component: RouteComponent,
   errorComponent: ({ error }) => (
     <Card captionSize={"lg"} caption={<span className="text-danger">Error</span>}>
       <pre>{error.message}</pre>
-      <pre>{error.cause}</pre>
+      <pre>{error.cause ? String(error.cause) : null}</pre>
     </Card>
   ),
 });
 
 function RouteComponent() {
+  const location = useLocation();
+  const showTabs =
+    location.pathname.includes("/research") || location.pathname.includes("/dataset");
+
   return (
-    <>
-      <Breadcrumbs />
-      <Outlet />
-    </>
+    <div className="flex flex-col">
+      <div className="flex items-end justify-between pl-2 pr-0 -mb-[1px] z-20">
+        <div className="pb-1.5">
+          <Breadcrumbs />
+        </div>
+        {showTabs && <ResearchDatasetTabs />}
+      </div>
+      <div className="flex-1 z-10">
+        <Outlet />
+      </div>
+    </div>
   );
 }

--- a/apps/frontend/src/routes/{-$lang}/_layout/_main/_other.tsx
+++ b/apps/frontend/src/routes/{-$lang}/_layout/_main/_other.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Outlet, useLocation } from "@tanstack/react-router";
+import { createFileRoute, Outlet } from "@tanstack/react-router";
 
 import { Breadcrumbs } from "@/components/Breadcrumb";
 import { Card } from "@/components/Card";
@@ -9,23 +9,19 @@ export const Route = createFileRoute("/{-$lang}/_layout/_main/_other")({
   errorComponent: ({ error }) => (
     <Card captionSize={"lg"} caption={<span className="text-danger">Error</span>}>
       <pre>{error.message}</pre>
-      <pre>{error.cause ? String(error.cause) : null}</pre>
+      <pre>{error.cause != null ? String(error.cause) : null}</pre>
     </Card>
   ),
 });
 
 function RouteComponent() {
-  const location = useLocation();
-  const showTabs =
-    location.pathname.includes("/research") || location.pathname.includes("/dataset");
-
   return (
     <div className="flex flex-col">
       <div className="flex items-end justify-between pl-2 pr-0 -mb-[1px] z-20">
         <div className="pb-1.5">
           <Breadcrumbs />
         </div>
-        {showTabs && <ResearchDatasetTabs />}
+        <ResearchDatasetTabs />
       </div>
       <div className="flex-1 z-10">
         <Outlet />

--- a/apps/frontend/src/routes/{-$lang}/_layout/_main/_other.tsx
+++ b/apps/frontend/src/routes/{-$lang}/_layout/_main/_other.tsx
@@ -9,7 +9,7 @@ export const Route = createFileRoute("/{-$lang}/_layout/_main/_other")({
   errorComponent: ({ error }) => (
     <Card captionSize={"lg"} caption={<span className="text-danger">Error</span>}>
       <pre>{error.message}</pre>
-      <pre>{error.cause != null ? String(error.cause) : null}</pre>
+      {error.cause != null && <pre>{String(error.cause)}</pre>}
     </Card>
   ),
 });


### PR DESCRIPTION
研究・データセット一覧ページのタブのスタイルを変更