### PR TITLE
Penqe/work

### DIFF
--- a/apps/frontend/localization/messages/en.json
+++ b/apps/frontend/localization/messages/en.json
@@ -424,7 +424,10 @@
   "Pagination": {
     "itemsPerPage": "Items per page",
     "previous": "Previous",
-    "next": "Next"
+    "next": "Next",
+    "page": "Page",
+    "pageNumber": "Page number",
+    "go": "Go"
   },
   "MergeWizard": {
     "field-status-conflict": "Values differ",

--- a/apps/frontend/localization/messages/ja.json
+++ b/apps/frontend/localization/messages/ja.json
@@ -426,7 +426,10 @@
   "Pagination": {
     "itemsPerPage": "1ページあたりのアイテム数",
     "previous": "前へ",
-    "next": "次へ"
+    "next": "次へ",
+    "page": "ページ",
+    "pageNumber": "ページ番号",
+    "go": "移動"
   },
   "MergeWizard": {
     "field-status-conflict": "値が異なります",

--- a/apps/frontend/src/components/DateTimePicker.tsx
+++ b/apps/frontend/src/components/DateTimePicker.tsx
@@ -7,39 +7,12 @@ import { Calendar } from "@/components/ui/calendar";
 import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 
-function toTimeString(date: Date): string {
-  const h = `${date.getUTCHours()}`.padStart(2, "0");
-  const m = `${date.getUTCMinutes()}`.padStart(2, "0");
-  return `${h}:${m}`;
-}
-
-function formatDisplay(date: Date): string {
-  const yyyy = date.getUTCFullYear();
-  const mm = `${date.getUTCMonth() + 1}`.padStart(2, "0");
-  const dd = `${date.getUTCDate()}`.padStart(2, "0");
-  const h = `${date.getUTCHours()}`.padStart(2, "0");
-  const min = `${date.getUTCMinutes()}`.padStart(2, "0");
-  return `${yyyy}-${mm}-${dd} ${h}:${min}`;
-}
-
-function calendarSelected(date: Date): Date {
-  // react-day-picker works in local time; shift UTC date into local so the calendar
-  // highlights the correct day regardless of timezone.
-  return new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
-}
-
-function mergeDateTime(calendarDay: Date, timeStr: string): Date {
-  const [h, m] = timeStr.split(":").map(Number);
-  return new Date(
-    Date.UTC(
-      calendarDay.getFullYear(),
-      calendarDay.getMonth(),
-      calendarDay.getDate(),
-      h ?? 0,
-      m ?? 0,
-    ),
-  );
-}
+import {
+  calendarSelected,
+  formatDisplay,
+  mergeDateTime,
+  toTimeString,
+} from "./dateTimePicker-utils";
 
 export function DateTimePicker({
   value,

--- a/apps/frontend/src/components/Pagination.tsx
+++ b/apps/frontend/src/components/Pagination.tsx
@@ -1,8 +1,12 @@
 import { useNavigate } from "@tanstack/react-router";
 import { useTranslations } from "use-intl";
 
+import { useEffect, useState } from "react";
+
 import type { Pagination as APIPagination } from "@humandbs/backend/types";
 
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
   Pagination as PaginationBase,
   PaginationContent,
@@ -86,11 +90,23 @@ interface PaginationProps {
 export function Pagination({ pagination, onItemsPerPageChange, className }: PaginationProps) {
   const navigate = useNavigate();
   const t = useTranslations("Pagination");
+  const [pageInput, setPageInput] = useState(String(pagination.page));
 
   const visiblePages = getVisiblePages(pagination.page, pagination.totalPages);
+  const visiblePageItems = visiblePages.map((pageNum, index) => ({
+    pageNum,
+    key:
+      pageNum === "ellipsis"
+        ? `ellipsis-${visiblePages[index - 1]}-${visiblePages[index + 1]}`
+        : pageNum,
+  }));
+
+  useEffect(() => {
+    setPageInput(String(pagination.page));
+  }, [pagination.page]);
 
   const handleItemsPerPageChange = (value: string) => {
-    const newItemsPerPage = parseInt(value);
+    const newItemsPerPage = parseInt(value, 10);
     if (onItemsPerPageChange) {
       onItemsPerPageChange(newItemsPerPage);
     }
@@ -98,6 +114,24 @@ export function Pagination({ pagination, onItemsPerPageChange, className }: Pagi
     navigate({
       to: ".",
       search: (prev) => ({ ...prev, page: 1, limit: newItemsPerPage }),
+      resetScroll: false,
+    });
+  };
+
+  const handlePageJump = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const requestedPage = Number(pageInput);
+    if (!Number.isInteger(requestedPage)) return;
+
+    const page = Math.min(pagination.totalPages, Math.max(1, requestedPage));
+    setPageInput(String(page));
+
+    if (page === pagination.page) return;
+
+    navigate({
+      to: ".",
+      search: (prev) => ({ ...prev, page }),
       resetScroll: false,
     });
   };
@@ -123,10 +157,10 @@ export function Pagination({ pagination, onItemsPerPageChange, className }: Pagi
             />
           </PaginationItem>
 
-          {visiblePages.map((pageNum, index) => {
+          {visiblePageItems.map(({ pageNum, key }) => {
             if (pageNum === "ellipsis") {
               return (
-                <PaginationItem key={`ellipsis-${pageNum}-${index}`}>
+                <PaginationItem key={key}>
                   <PaginationEllipsis />
                 </PaginationItem>
               );
@@ -159,6 +193,28 @@ export function Pagination({ pagination, onItemsPerPageChange, className }: Pagi
               })}
               resetScroll={false}
             />
+          </PaginationItem>
+          <PaginationItem>
+            <form className="flex items-center gap-2" onSubmit={handlePageJump}>
+              <label className="text-muted-foreground text-sm" htmlFor="pagination-page">
+                {t("page")}
+              </label>
+              <Input
+                aria-label={t("pageNumber")}
+                className="w-16 text-center"
+                id="pagination-page"
+                max={pagination.totalPages}
+                min="1"
+                onChange={(event) => setPageInput(event.target.value)}
+                required
+                step="1"
+                type="number"
+                value={pageInput}
+              />
+              <Button size="default" type="submit" variant="outline">
+                {t("go")}
+              </Button>
+            </form>
           </PaginationItem>
         </PaginationContent>
       </PaginationBase>

--- a/apps/frontend/src/components/SearchCaption.tsx
+++ b/apps/frontend/src/components/SearchCaption.tsx
@@ -3,8 +3,8 @@ import { useTranslations } from "use-intl";
 
 import { startTransition, useEffect, useState } from "react";
 
-import { Input } from "@/components/Input";
 import { CustomSearchIcon } from "@/components/CustomSearchIcon";
+import { Input } from "@/components/Input";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -19,6 +19,7 @@ export function SearchCaption({
   onCopy,
   onCsv,
   onExcel,
+  isExporting = false,
   filterButtonRef,
   sortControl,
 }: {
@@ -32,6 +33,7 @@ export function SearchCaption({
   onCopy?: () => void;
   onCsv?: () => void;
   onExcel?: () => void;
+  isExporting?: boolean;
   filterButtonRef?: React.Ref<HTMLButtonElement>;
   sortControl?: React.ReactNode;
 }) {
@@ -69,13 +71,28 @@ export function SearchCaption({
       <div className="flex flex-wrap items-center gap-4">
         {sortControl}
         <div className="flex gap-1">
-          <Button variant={"captionAction"} size={"captionAction"} onClick={onCopy}>
+          <Button
+            variant={"captionAction"}
+            size={"captionAction"}
+            onClick={onCopy}
+            disabled={isExporting}
+          >
             {t("copy")}
           </Button>
-          <Button variant={"captionAction"} size={"captionAction"} onClick={onCsv}>
+          <Button
+            variant={"captionAction"}
+            size={"captionAction"}
+            onClick={onCsv}
+            disabled={isExporting}
+          >
             CSV
           </Button>
-          <Button variant={"captionAction"} size={"captionAction"} onClick={onExcel}>
+          <Button
+            variant={"captionAction"}
+            size={"captionAction"}
+            onClick={onExcel}
+            disabled={isExporting}
+          >
             Excel
           </Button>
         </div>
@@ -109,7 +126,7 @@ export function SearchCaption({
                   variant="accent"
                   size="icon"
                   type="button"
-                  className="pointer-events-auto aspect-square h-10 rounded-full p-0 flex items-center justify-center"
+                  className="pointer-events-auto flex aspect-square h-10 items-center justify-center rounded-full p-0"
                   onClick={handleSearch}
                   aria-label={t("search")}
                 >
@@ -128,7 +145,8 @@ export function SearchCaption({
             variant="captionAction"
             size="captionAction"
             className={cn("flex items-center gap-2 transition-colors", {
-              "border-secondary bg-secondary text-white hover:bg-secondary hover:text-white": isPanelOpen,
+              "border-secondary bg-secondary text-white hover:bg-secondary hover:text-white":
+                isPanelOpen,
             })}
             onClick={onFilterClick}
             type="button"

--- a/apps/frontend/src/components/dateTimePicker-utils.test.ts
+++ b/apps/frontend/src/components/dateTimePicker-utils.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from "bun:test";
+
+import { mergeDateTime } from "./dateTimePicker-utils";
+
+test("stores the selected date and time in the administrator's local timezone", () => {
+  const selectedDay = new Date(2026, 6, 27);
+
+  expect(mergeDateTime(selectedDay, "15:00")).toEqual(new Date(2026, 6, 27, 15, 0));
+});

--- a/apps/frontend/src/components/dateTimePicker-utils.ts
+++ b/apps/frontend/src/components/dateTimePicker-utils.ts
@@ -1,0 +1,34 @@
+/**
+ * DateTimePicker helpers that keep the admin's displayed wall-clock time intact.
+ * They use local Date accessors because scheduled news is entered in local time.
+ * The resulting Date still serializes as an absolute instant for `timestamptz` storage.
+ */
+export function toTimeString(date: Date): string {
+  const h = `${date.getHours()}`.padStart(2, "0");
+  const m = `${date.getMinutes()}`.padStart(2, "0");
+  return `${h}:${m}`;
+}
+
+export function formatDisplay(date: Date): string {
+  const yyyy = date.getFullYear();
+  const mm = `${date.getMonth() + 1}`.padStart(2, "0");
+  const dd = `${date.getDate()}`.padStart(2, "0");
+  const h = `${date.getHours()}`.padStart(2, "0");
+  const min = `${date.getMinutes()}`.padStart(2, "0");
+  return `${yyyy}-${mm}-${dd} ${h}:${min}`;
+}
+
+export function calendarSelected(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+export function mergeDateTime(calendarDay: Date, timeStr: string): Date {
+  const [h, m] = timeStr.split(":").map(Number);
+  return new Date(
+    calendarDay.getFullYear(),
+    calendarDay.getMonth(),
+    calendarDay.getDate(),
+    h ?? 0,
+    m ?? 0,
+  );
+}

--- a/apps/frontend/src/repositories/alert.ts
+++ b/apps/frontend/src/repositories/alert.ts
@@ -6,6 +6,7 @@ import { localeSchema } from "@/config/i18n";
 import type { DB } from "@/db/database";
 import { db } from "@/db/database";
 import { alert, alertTranslation, user } from "@/db/schema";
+import { toDateStringInTimeZone } from "@/utils/dates";
 
 import { sortTranslationsByLocale } from "./utils";
 
@@ -162,7 +163,7 @@ function mapAlertRows(
 export function createAlertsRepository(database: DB): AlertsRepository {
   return {
     listActive: async ({ lang }) => {
-      const now = new Date().toISOString().slice(0, 10);
+      const now = toDateStringInTimeZone(new Date(), process.env.TZ ?? "Asia/Tokyo");
       const alertTranslations = await database
         .select({
           id: alert.id,

--- a/apps/frontend/src/routes/{-$lang}/_layout/_authed/admin/header-footer.tsx
+++ b/apps/frontend/src/routes/{-$lang}/_layout/_authed/admin/header-footer.tsx
@@ -571,7 +571,7 @@ function RouteComponent() {
         <div className="flex flex-col gap-5 px-5 pt-5 pb-5">
           {/* Navbar preview */}
           <section className="rounded-md border border-gray-200 p-4">
-            <h2 className="font-medium text-base">Navbar</h2>
+            <h2 className="font-medium text-base">Header</h2>
             <p className="mt-1 text-foreground-light text-sm">{tNav("drag-navbar-hint")}</p>
             <div className="mt-4">
               <NavbarEditor

--- a/apps/frontend/src/routes/{-$lang}/_layout/_main/_home.tsx
+++ b/apps/frontend/src/routes/{-$lang}/_layout/_main/_home.tsx
@@ -130,14 +130,15 @@ function RouteComponent() {
         </Card>
       </section>
       <div className="w-full">
-        <Suspense
+        {/*<Suspense
           fallback={<div className="flex h-40 w-full items-center justify-center">Loading...</div>}
         >
           <LazyFrontStats />
-        </Suspense>
+        </Suspense>*/}
       </div>
     </section>
   );
 }
 
-const LazyFrontStats = lazy(() => import("@/components/FrontStatsVisualization/index"));
+// Temporary remove stats from front page
+// const LazyFrontStats = lazy(() => import("@/components/FrontStatsVisualization/index"));

--- a/apps/frontend/src/routes/{-$lang}/_layout/_main/_home.tsx
+++ b/apps/frontend/src/routes/{-$lang}/_layout/_main/_home.tsx
@@ -129,13 +129,14 @@ function RouteComponent() {
           </ErrorResetBoundary>
         </Card>
       </section>
-      <div className="w-full">
-        {/*<Suspense
+      {/*<div className="w-full">
+       <Suspense
           fallback={<div className="flex h-40 w-full items-center justify-center">Loading...</div>}
         >
           <LazyFrontStats />
-        </Suspense>*/}
+        </Suspense>
       </div>
+      */}
     </section>
   );
 }

--- a/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/dataset/index.tsx
+++ b/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/dataset/index.tsx
@@ -27,7 +27,6 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { i18n } from "@/config/i18n";
 import { useCartTableHeader } from "@/hooks/useCart";
 import { useFilters } from "@/hooks/useFilters";
-import { useMaxHeight } from "@/hooks/useMaxHeight";
 import { FA_ICONS } from "@/lib/faIcons";
 import { cn } from "@/lib/utils";
 import { getDatasetsPaginatedQueryOptions } from "@/serverFunctions/datasets";
@@ -196,16 +195,11 @@ function FacetsAdapter({ onClose }: { onClose: () => void }) {
 
 function CardContent() {
   const t = useTranslations("Dataset-list");
-  const { containerRef, maxHeight } = useMaxHeight(130);
 
   return (
     <>
       <InfoBadge>{t("cart-note")}</InfoBadge>
-      <div
-        ref={containerRef}
-        style={{ maxHeight }}
-        className="flex min-w-full flex-1 flex-col overflow-auto"
-      >
+      <div className="min-w-full overflow-x-auto">
         <TableWrapper />
       </div>
       <PaginationWrapper />
@@ -340,7 +334,7 @@ function TableWrapper() {
   if (!data || (isFetching && !isPlaceholderData)) {
     return (
       <TableLoadingSpinner
-        className="min-h-full w-max min-w-full flex-1 text-sm"
+        className="w-max min-w-full text-sm"
         columns={datasetsColumns}
         meta={{ t, lang }}
       />
@@ -349,7 +343,7 @@ function TableWrapper() {
 
   return (
     <Table
-      className={cn("min-h-full w-max min-w-full flex-1 text-sm")}
+      className={cn("w-max min-w-full text-sm")}
       meta={{ t, lang }}
       columns={datasetsColumns}
       data={data.data}

--- a/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/dataset/index.tsx
+++ b/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/dataset/index.tsx
@@ -4,7 +4,7 @@ import { createColumnHelper } from "@tanstack/react-table";
 import { zodValidator } from "@tanstack/zod-adapter";
 import { useLocale, useTranslations } from "use-intl";
 
-import { startTransition, useEffect, useMemo, useRef } from "react";
+import { startTransition, useEffect, useMemo, useRef, useState } from "react";
 
 import type { DatasetSearchBody, DatasetSearchResponse } from "@humandbs/backend/types";
 
@@ -31,8 +31,9 @@ import { FA_ICONS } from "@/lib/faIcons";
 import { cn } from "@/lib/utils";
 import { getDatasetsPaginatedQueryOptions } from "@/serverFunctions/datasets";
 import { getAllFacetsQueryOptions } from "@/serverFunctions/facets";
+import { $exportDatasets } from "@/serverFunctions/searchExports";
 import { buildFacetSections } from "@/utils/build-facet-sections";
-import { copyTableData, downloadCsv, downloadExcel } from "@/utils/export-table";
+import { copyExportResponse, downloadExportResponse } from "@/utils/export-table";
 import { isCancelledError } from "@/utils/is-cancelled-error";
 import { datasetListQuerySchema } from "@/utils/query-params";
 
@@ -71,32 +72,28 @@ function RouteComponent() {
   const { lang } = Route.useRouteContext();
   const { filters, setFilters } = useFilters(Route.id);
 
-  const { data } = useDatasetsSearchQuery();
+  const [isExporting, setIsExporting] = useState(false);
 
-  const exportData = useMemo(() => {
-    type Row = DatasetSearchResponse["data"][number];
-    const columns: { header: string; value: (row: Row) => string }[] = [
-      { header: t("datasetId"), value: (row) => row.datasetId },
-      { header: t("releaseDate"), value: (row) => row.releaseDate ?? "" },
-      {
-        header: t("typeOfData"),
-        value: (row) => row.typeOfData?.[lang] ?? "",
-      },
-      {
-        header: t("experiments"),
-        value: (row) =>
-          row.experiments
-            .map((e) => e.header?.[lang]?.text ?? "")
-            .filter(Boolean)
-            .join("; "),
-      },
-      { header: t("criteria"), value: (row) => row.criteria ?? "" },
-    ];
-    return {
-      headers: columns.map((c) => c.header),
-      rows: (data?.data ?? []).map((row) => columns.map((c) => c.value(row))),
-    };
-  }, [data, lang, t]);
+  async function exportAll(format: "copy" | "csv" | "excel") {
+    if (isExporting) return;
+
+    const { page: _page, limit: _limit, ...exportSearch } = search;
+    setIsExporting(true);
+    try {
+      const response = await $exportDatasets({
+        data: { format, search: { ...exportSearch, lang } },
+      });
+      if (format === "copy") {
+        await copyExportResponse(response);
+      } else {
+        await downloadExportResponse(response);
+      }
+    } catch (error) {
+      console.error("Failed to export dataset table:", error);
+    } finally {
+      setIsExporting(false);
+    }
+  }
 
   const filtersCount = Object.keys(filters.filters || {}).length;
   return (
@@ -114,16 +111,17 @@ function RouteComponent() {
           resultsCount={<ResultsCount />}
           filtersCount={filtersCount}
           isPanelOpen={isOpen}
+          isExporting={isExporting}
           onFilterClick={onFilterClick}
           sortControl={<DatasetSortSelect />}
           onCopy={() => {
-            copyTableData(exportData);
+            void exportAll("copy");
           }}
           onCsv={() => {
-            downloadCsv(exportData, "dataset-list");
+            void exportAll("csv");
           }}
           onExcel={() => {
-            downloadExcel(exportData, "dataset-list");
+            void exportAll("excel");
           }}
         />
       )}

--- a/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/research/$humId/-VersionCard.tsx
+++ b/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/research/$humId/-VersionCard.tsx
@@ -71,7 +71,6 @@ export function VersionCard({
         </CardCaption>
       }
     >
-      {/*grid grid-cols-1 gap-x-8 gap-y-4 sm:grid-cols-2 */}
       <article>
         <ContentHeader>{t("Research.title")}</ContentHeader>
         <h2 className="text">{versionData.title[lang]}</h2>
@@ -423,17 +422,16 @@ const researchProjectsColumns = [
   researchProjectsColumnsHelper.accessor("url", {
     id: "researchProjectId",
     header: (ctx) => ctx.table.options.meta?.t("Research.researchProject.URL"),
-    cell: (ctx) => (
-      <a
-        href={
-          ctx.getValue()?.[ctx.table.options.meta?.lang ?? i18n.defaultLocale]?.url ?? undefined
-        }
-        className="break-all text-sm"
-      >
-        {ctx.getValue()?.[ctx.table.options.meta?.lang ?? i18n.defaultLocale]?.text ||
-          ctx.getValue()?.[ctx.table.options.meta?.lang ?? i18n.defaultLocale]?.url ||
-          "URL"}
-      </a>
-    ),
+    cell: (ctx) => {
+      const url = ctx.getValue()?.[ctx.table.options.meta?.lang ?? i18n.defaultLocale]?.url;
+      if (!url) return null;
+      return (
+        <a href={url} className="break-all text-sm">
+          {ctx.getValue()?.[ctx.table.options.meta?.lang ?? i18n.defaultLocale]?.text ||
+            url ||
+            "URL"}
+        </a>
+      );
+    },
   }),
 ];

--- a/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/research/$humId/-VersionCard.tsx
+++ b/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/research/$humId/-VersionCard.tsx
@@ -76,25 +76,34 @@ export function VersionCard({
         <ContentHeader>{t("Research.title")}</ContentHeader>
         <h2 className="text">{versionData.title[lang]}</h2>
         <ContentHeader>{t("Research.researchOverview")}</ContentHeader>
-        <div className="sm:columns-2 sm:break-inside-avoid-column [&_.custom-prose]:mt-1 [&_.custom-prose_:first-child]:mt-0">
-          <h3 className="break-inside-avoid font-extrabold">{t("Research.aims")}:</h3>
-          <Markdown
-            className="text-base"
-            contentHtml={{ markup: versionData.summary.aims[lang]?.renderedHtml ?? "" }}
-          />
+        <dl className="sm:columns-2 sm:break-inside-avoid-column [&>_div]:break-inside-avoid [&_.custom-prose]:mt-1 [&_.custom-prose_:first-child]:mt-0 [&_dt]:font-extrabold">
+          <div>
+            <dt>{t("Research.aims")}:</dt>
+            <dd>
+              <Markdown
+                className="text-base"
+                contentHtml={{ markup: versionData.summary.aims[lang]?.renderedHtml ?? "" }}
+              />
+            </dd>
+          </div>
+          <div>
+            <dt>{t("Research.methods")}:</dt>
+            <dd>
+              <Markdown
+                className="text-base"
+                contentHtml={{ markup: versionData.summary.methods[lang]?.renderedHtml ?? "" }}
+              />
+            </dd>
+          </div>
 
-          <h3 className="break-inside-avoid font-extrabold">{t("Research.methods")}:</h3>
-          <Markdown
-            className="text-base"
-            contentHtml={{ markup: versionData.summary.methods[lang]?.renderedHtml ?? "" }}
-          />
-
-          <h3 className="break-inside-avoid font-extrabold">{t("Research.targets")}:</h3>
-          <Markdown
-            className="text-base"
-            contentHtml={{ markup: versionData.summary.targets[lang]?.renderedHtml ?? "" }}
-          />
-        </div>
+          <div>
+            <dt>{t("Research.targets")}:</dt>
+            <Markdown
+              className="text-base"
+              contentHtml={{ markup: versionData.summary.targets[lang]?.renderedHtml ?? "" }}
+            />
+          </div>
+        </dl>
       </article>
       <Separator className="-mx-4" />
       <section>

--- a/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/research/index.tsx
+++ b/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/research/index.tsx
@@ -31,7 +31,6 @@ import type { Locale } from "@/config/i18n";
 import { i18n } from "@/config/i18n";
 import { useCartTableHeader } from "@/hooks/useCart";
 import { useFilters } from "@/hooks/useFilters";
-import { useMaxHeight } from "@/hooks/useMaxHeight";
 import { FA_ICONS } from "@/lib/faIcons";
 import type { ResearchSearchResponseWithTypedCriteria, ResearchSummary } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -228,16 +227,11 @@ function FacetsAdapter({ onClose }: { onClose: () => void }) {
 
 function CardContent() {
   const t = useTranslations("Research-list");
-  const { containerRef, maxHeight } = useMaxHeight(130);
 
   return (
     <>
       <InfoBadge>{t("cart-note")}</InfoBadge>
-      <div
-        ref={containerRef}
-        style={{ maxHeight }}
-        className="flex min-w-full flex-1 flex-col overflow-auto"
-      >
+      <div className="min-w-full overflow-x-auto">
         <TableWrapper />
       </div>
       <PaginationWrapper />
@@ -377,7 +371,7 @@ function TableWrapper() {
   if (!researchesData || (isFetching && !isPlaceholderData))
     return (
       <TableLoadingSpinner
-        className="min-h-full w-max min-w-full flex-1 text-sm"
+        className="w-max min-w-full text-sm"
         columns={columns}
         meta={{ t, lang }}
       />
@@ -385,7 +379,7 @@ function TableWrapper() {
 
   return (
     <Table
-      className={cn("min-h-full w-max min-w-full flex-1 text-sm")}
+      className={cn("w-max min-w-full text-sm")}
       columns={columns}
       data={researchesData.data}
       meta={{ t, lang }}

--- a/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/research/index.tsx
+++ b/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/research/index.tsx
@@ -1,11 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
 import { ClientOnly, createFileRoute } from "@tanstack/react-router";
 import { createColumnHelper } from "@tanstack/react-table";
-import type { Translator } from "node_modules/use-intl/dist/types/core/createTranslator";
-import type { Messages } from "use-intl";
 import { useLocale, useTranslations } from "use-intl";
 
-import { startTransition, useEffect, useMemo, useRef } from "react";
+import { startTransition, useEffect, useMemo, useRef, useState } from "react";
 
 import type { ResearchSearchBody } from "@humandbs/backend/types";
 import { ResearchSearchBodySchema } from "@humandbs/backend/types";
@@ -27,18 +25,18 @@ import { SortDropdown } from "@/components/SortDropdown";
 import { Table, TableLoadingSpinner } from "@/components/Table";
 import { TextWithIcon } from "@/components/TextWithIcon";
 import { Skeleton } from "@/components/ui/skeleton";
-import type { Locale } from "@/config/i18n";
 import { i18n } from "@/config/i18n";
 import { useCartTableHeader } from "@/hooks/useCart";
 import { useFilters } from "@/hooks/useFilters";
 import { FA_ICONS } from "@/lib/faIcons";
-import type { ResearchSearchResponseWithTypedCriteria, ResearchSummary } from "@/lib/types";
+import type { ResearchSummary } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { getDatasetsOfResearchQueryOptions } from "@/serverFunctions/datasets";
 import { getAllFacetsQueryOptions } from "@/serverFunctions/facets";
 import { getResearchesQueryOptions } from "@/serverFunctions/researches";
+import { $exportResearches } from "@/serverFunctions/searchExports";
 import { buildFacetSections } from "@/utils/build-facet-sections";
-import { copyTableData, downloadCsv, downloadExcel } from "@/utils/export-table";
+import { copyExportResponse, downloadExportResponse } from "@/utils/export-table";
 
 const researchesSearchParamsSchema = ResearchSearchBodySchema.omit({
   lang: true,
@@ -75,58 +73,34 @@ export const Route = createFileRoute("/{-$lang}/_layout/_main/_other/research/")
   },
 });
 
-type Row = ResearchSearchResponseWithTypedCriteria["data"][number];
-
-function getRawData(
-  data: ResearchSearchResponseWithTypedCriteria | undefined,
-  t: Translator<Messages, "Research">,
-  lang: Locale,
-) {
-  const columns: { header: string; value: (row: Row) => string }[] = [
-    { header: t("research-id"), value: (row) => row.humId },
-    { header: t("datasets"), value: (row) => row.datasetIds.join(", ") },
-    { header: t("title"), value: (row) => row.title[lang] ?? "" },
-    {
-      header: t("datePublished"),
-      value: (row) => `${row.versions[0]?.releaseDate ?? ""} (${row.versions[0]?.version ?? ""})`,
-    },
-    {
-      header: t("dateModified"),
-      value: (row) =>
-        `${row.versions.at(-1)?.releaseDate ?? ""} (${row.versions.at(-1)?.version ?? ""})`,
-    },
-    { header: t("methods"), value: (row) => row.methods ?? "" },
-    { header: t("typeOfData"), value: (row) => row.typeOfData.join(", ") },
-    { header: t("platforms"), value: (row) => row.platforms.join(", ") },
-    { header: t("targets"), value: (row) => row.targets },
-    { header: t("criteria"), value: (row) => row.criteria.join(", ") },
-    {
-      header: t("dataProvider"),
-      value: (row) => row.dataProvider.join(", "),
-    },
-  ];
-
-  return {
-    headers: columns.map((c) => c.header),
-    rows: (data?.data ?? []).map((row) => columns.map((c) => c.value(row))),
-  };
-}
-
-function useGetRawData() {
-  const { data: researchesData } = useResearchesSearchQuery();
-
-  const lang = useLocale();
-  const t = useTranslations("Research");
-
-  return getRawData(researchesData, t, lang);
-}
-
 function RouteComponent() {
   const t = useTranslations("Research");
   const search = Route.useSearch();
-  const exportData = useGetRawData();
+  const { lang } = Route.useRouteContext();
+  const [isExporting, setIsExporting] = useState(false);
 
   const { setFilters, filters } = useFilters(Route.id);
+
+  async function exportAll(format: "copy" | "csv" | "excel") {
+    if (isExporting) return;
+
+    const { page: _page, limit: _limit, ...exportSearch } = search;
+    setIsExporting(true);
+    try {
+      const response = await $exportResearches({
+        data: { format, search: { ...exportSearch, lang } },
+      });
+      if (format === "copy") {
+        await copyExportResponse(response);
+      } else {
+        await downloadExportResponse(response);
+      }
+    } catch (error) {
+      console.error("Failed to export research table:", error);
+    } finally {
+      setIsExporting(false);
+    }
+  }
 
   return (
     <FilterableCard
@@ -144,15 +118,16 @@ function RouteComponent() {
           filtersCount={Object.keys(filters.datasetFilters || {}).length}
           onFilterClick={onFilterClick}
           isPanelOpen={isOpen}
+          isExporting={isExporting}
           sortControl={<ResearchSortSelect />}
           onCopy={() => {
-            copyTableData(exportData);
+            void exportAll("copy");
           }}
           onCsv={() => {
-            downloadCsv(exportData, "research-list");
+            void exportAll("csv");
           }}
           onExcel={() => {
-            downloadExcel(exportData, "research-list");
+            void exportAll("excel");
           }}
         />
       )}

--- a/apps/frontend/src/serverFunctions/assets.test.ts
+++ b/apps/frontend/src/serverFunctions/assets.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from "bun:test";
+
+import { normalizeAssetFolderPath } from "./assets";
+
+test("allows the asset root as an upload folder", () => {
+  expect(normalizeAssetFolderPath("")).toBe("");
+});

--- a/apps/frontend/src/serverFunctions/assets.ts
+++ b/apps/frontend/src/serverFunctions/assets.ts
@@ -29,6 +29,11 @@ function normalizeRelativeAssetPath(input: string) {
   return normalized;
 }
 
+export function normalizeAssetFolderPath(input: string) {
+  const folderPath = input.trim();
+  return folderPath ? normalizeRelativeAssetPath(folderPath) : "";
+}
+
 function getAbsoluteAssetPath(relativePath: string) {
   const ASSET_DIR = getAssetDir();
   return path.join(ASSET_DIR, relativePath);
@@ -173,7 +178,7 @@ export const $uploadAsset = createServerFn({ method: "POST" })
       throw new Error("Invalid file");
     }
 
-    const folderPath = normalizeRelativeAssetPath(
+    const folderPath = normalizeAssetFolderPath(
       assetFolderPathSchema.parse((data.get("folderPath") as string) ?? ""),
     );
 

--- a/apps/frontend/src/serverFunctions/searchExports.ts
+++ b/apps/frontend/src/serverFunctions/searchExports.ts
@@ -1,0 +1,130 @@
+import { createServerFn } from "@tanstack/react-start";
+import { z } from "zod";
+
+import type {
+  DatasetSearchBody,
+  DatasetSearchResponse,
+  ResearchSearchBody,
+} from "@humandbs/backend/types";
+import { DatasetSearchBodySchema, ResearchSearchBodySchema } from "@humandbs/backend/types";
+
+import { messages } from "@/config/messages";
+import type { ResearchSearchResponseWithTypedCriteria } from "@/lib/types";
+import { requestSignalMiddleware } from "@/middleware/requestSignalMiddleware";
+import { api } from "@/services/backend";
+import type { TableExportData, TableExportFormat } from "@/utils/export-table-server";
+import { createTableExportResponse } from "@/utils/export-table-server";
+import { $$getJWT } from "@/utils/jwt-helpers";
+
+const tableExportFormatSchema = z.enum(["copy", "csv", "excel"]);
+
+const searchExportSchema = <T extends z.ZodObject>(search: T) =>
+  z.object({ format: tableExportFormatSchema, search });
+
+const datasetSearchExportSchema = searchExportSchema(
+  DatasetSearchBodySchema.omit({ page: true, limit: true, includeFacets: true }),
+);
+const researchSearchExportSchema = searchExportSchema(
+  ResearchSearchBodySchema.omit({ page: true, limit: true, includeFacets: true }),
+);
+
+type DatasetExportSearch = Omit<DatasetSearchBody, "page" | "limit" | "includeFacets">;
+type ResearchExportSearch = Omit<ResearchSearchBody, "page" | "limit" | "includeFacets">;
+
+function datasetTableData(
+  datasets: DatasetSearchResponse["data"],
+  search: DatasetExportSearch,
+): TableExportData {
+  const labels = messages[search.lang].Dataset;
+  const columns: {
+    header: string;
+    value: (row: DatasetSearchResponse["data"][number]) => string;
+  }[] = [
+    { header: labels.datasetId, value: (row) => row.datasetId },
+    { header: labels.releaseDate, value: (row) => row.releaseDate ?? "" },
+    { header: labels.typeOfData, value: (row) => row.typeOfData?.[search.lang] ?? "" },
+    {
+      header: labels.experiments,
+      value: (row) =>
+        row.experiments
+          .map((experiment) => experiment.header?.[search.lang]?.text ?? "")
+          .filter(Boolean)
+          .join("; "),
+    },
+    { header: labels.criteria, value: (row) => row.criteria ?? "" },
+  ];
+
+  return {
+    headers: columns.map((column) => column.header),
+    rows: datasets.map((dataset) => columns.map((column) => column.value(dataset))),
+  };
+}
+
+function researchTableData(
+  researches: ResearchSearchResponseWithTypedCriteria["data"],
+  search: ResearchExportSearch,
+): TableExportData {
+  const labels = messages[search.lang].Research;
+  const columns: {
+    header: string;
+    value: (row: ResearchSearchResponseWithTypedCriteria["data"][number]) => string;
+  }[] = [
+    { header: labels["research-id"], value: (row) => row.humId },
+    { header: labels.datasets, value: (row) => row.datasetIds.join(", ") },
+    { header: labels.title, value: (row) => row.title[search.lang] ?? "" },
+    {
+      header: labels.datePublished,
+      value: (row) => `${row.versions[0]?.releaseDate ?? ""} (${row.versions[0]?.version ?? ""})`,
+    },
+    {
+      header: labels.dateModified,
+      value: (row) =>
+        `${row.versions.at(-1)?.releaseDate ?? ""} (${row.versions.at(-1)?.version ?? ""})`,
+    },
+    { header: labels.methods, value: (row) => row.methods ?? "" },
+    { header: labels.typeOfData, value: (row) => row.typeOfData.join(", ") },
+    { header: labels.platforms, value: (row) => row.platforms.join(", ") },
+    { header: labels.targets, value: (row) => row.targets },
+    { header: labels.criteria, value: (row) => row.criteria.join(", ") },
+    { header: labels.dataProvider, value: (row) => row.dataProvider.join(", ") },
+  ];
+
+  return {
+    headers: columns.map((column) => column.header),
+    rows: researches.map((research) => columns.map((column) => column.value(research))),
+  };
+}
+
+export const $exportDatasets = createServerFn({ method: "POST" })
+  .middleware([requestSignalMiddleware])
+  .inputValidator(datasetSearchExportSchema)
+  .handler(async ({ data, context }) => {
+    const datasets = await api.searchDatasetsAll(
+      data.search,
+      $$getJWT() ?? undefined,
+      context.requestSignal,
+    );
+    return createTableExportResponse(
+      datasetTableData(datasets, data.search),
+      "dataset-list",
+      data.format,
+    );
+  });
+
+export const $exportResearches = createServerFn({ method: "POST" })
+  .middleware([requestSignalMiddleware])
+  .inputValidator(researchSearchExportSchema)
+  .handler(async ({ data, context }) => {
+    const researches = await api.searchResearchesAll(
+      data.search,
+      $$getJWT() ?? undefined,
+      context.requestSignal,
+    );
+    return createTableExportResponse(
+      researchTableData(researches, data.search),
+      "research-list",
+      data.format,
+    );
+  });
+
+export type SearchExportFormat = TableExportFormat;

--- a/apps/frontend/src/services/backend.ts
+++ b/apps/frontend/src/services/backend.ts
@@ -45,6 +45,7 @@ import type {
   DatasetTemplateResponse,
   ResearchTemplateResponse,
 } from "../../../backend/src/api/types/templates";
+import { collectAllPages, createAllSearchPage } from "./search-all";
 
 const getBackendBaseUrl = createIsomorphicFn()
   .client(() => `/api`)
@@ -217,6 +218,9 @@ function authHeader(accessToken: string): HeadersInit {
   return { Authorization: `Bearer ${accessToken}` };
 }
 
+type ResearchSearchAllConditions = Omit<ResearchSearchBody, "page" | "limit" | "includeFacets">;
+type DatasetSearchAllConditions = Omit<DatasetSearchBody, "page" | "limit" | "includeFacets">;
+
 interface APIService {
   getResearchListPaginated(
     query: {
@@ -266,11 +270,21 @@ interface APIService {
     accessToken?: string,
     signal?: AbortSignal,
   ): Promise<ResearchSearchResponseWithTypedCriteria>;
+  searchResearchesAll(
+    query: ResearchSearchAllConditions,
+    accessToken?: string,
+    signal?: AbortSignal,
+  ): Promise<ResearchSearchResponseWithTypedCriteria["data"]>;
   searchDatasets(
     query: DatasetSearchBody,
     accessToken?: string,
     signal?: AbortSignal,
   ): Promise<DatasetSearchResponse>;
+  searchDatasetsAll(
+    query: DatasetSearchAllConditions,
+    accessToken?: string,
+    signal?: AbortSignal,
+  ): Promise<DatasetSearchResponse["data"]>;
   getAllFacets(): Promise<{ data: AllFacetsResponse }>;
   createResearch(
     body: CreateResearchRequest,
@@ -397,12 +411,24 @@ const api: APIService = {
     );
   },
 
+  searchResearchesAll(query, accessToken, signal) {
+    return collectAllPages((page) =>
+      api.searchResearches(createAllSearchPage(query, page), accessToken, signal),
+    );
+  },
+
   searchDatasets(query, accessToken, signal) {
     return post<DatasetSearchResponse>(
       `/dataset/search`,
       query,
       accessToken ? authHeader(accessToken) : undefined,
       signal,
+    );
+  },
+
+  searchDatasetsAll(query, accessToken, signal) {
+    return collectAllPages((page) =>
+      api.searchDatasets(createAllSearchPage(query, page), accessToken, signal),
     );
   },
 

--- a/apps/frontend/src/services/search-all.test.ts
+++ b/apps/frontend/src/services/search-all.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+
+import { collectAllPages, createAllSearchPage } from "./search-all";
+
+test("createAllSearchPage uses the maximum page size and disables facets", () => {
+  expect(createAllSearchPage({ lang: "ja", order: "asc" }, 2)).toEqual({
+    lang: "ja",
+    order: "asc",
+    page: 2,
+    limit: 100,
+    includeFacets: false,
+  });
+});
+
+describe("collectAllPages", () => {
+  test("fetches the remaining pages with five concurrent requests and preserves record order", async () => {
+    const requestedPages: number[] = [];
+    let activeRequests = 0;
+    let maxActiveRequests = 0;
+
+    const data = await collectAllPages(async (page) => {
+      requestedPages.push(page);
+      if (page === 1) {
+        return {
+          data: [10, 11],
+          meta: { pagination: { totalPages: 12 } },
+        };
+      }
+
+      activeRequests += 1;
+      maxActiveRequests = Math.max(maxActiveRequests, activeRequests);
+      await Promise.resolve();
+      activeRequests -= 1;
+
+      return {
+        data: [page * 10, page * 10 + 1],
+        meta: { pagination: { totalPages: 12 } },
+      };
+    });
+
+    expect(requestedPages).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+    expect(maxActiveRequests).toBe(5);
+    expect(data).toEqual([
+      10, 11, 20, 21, 30, 31, 40, 41, 50, 51, 60, 61, 70, 71, 80, 81, 90, 91, 100, 101, 110, 111,
+      120, 121,
+    ]);
+  });
+
+  test("rejects instead of returning partial data when a later page fails", async () => {
+    const requestedPages: number[] = [];
+    const failure = new Error("Page request failed");
+
+    await expect(
+      collectAllPages(async (page) => {
+        requestedPages.push(page);
+        if (page === 2) throw failure;
+        return {
+          data: [page],
+          meta: { pagination: { totalPages: 3 } },
+        };
+      }),
+    ).rejects.toThrow(failure);
+
+    expect(requestedPages).toEqual([1, 2, 3]);
+  });
+});

--- a/apps/frontend/src/services/search-all.ts
+++ b/apps/frontend/src/services/search-all.ts
@@ -1,0 +1,37 @@
+type PaginatedResponse<T> = {
+  data: T[];
+  meta: {
+    pagination: {
+      totalPages: number;
+    };
+  };
+};
+
+export const SEARCH_ALL_PAGE_LIMIT = 100;
+const SEARCH_ALL_CONCURRENCY = 5;
+
+export function createAllSearchPage<T extends object>(conditions: T, page: number) {
+  return { ...conditions, page, limit: SEARCH_ALL_PAGE_LIMIT, includeFacets: false };
+}
+
+/** Fetches the first page, then the remaining pages in bounded parallel batches. */
+export async function collectAllPages<T>(
+  fetchPage: (page: number) => Promise<PaginatedResponse<T>>,
+): Promise<T[]> {
+  const firstPage = await fetchPage(1);
+  const data = [...firstPage.data];
+  const remainingPages = Array.from(
+    { length: Math.max(0, firstPage.meta.pagination.totalPages - 1) },
+    (_, index) => index + 2,
+  );
+
+  for (let index = 0; index < remainingPages.length; index += SEARCH_ALL_CONCURRENCY) {
+    const responses = await Promise.all(
+      remainingPages.slice(index, index + SEARCH_ALL_CONCURRENCY).map(fetchPage),
+    );
+
+    for (const response of responses) data.push(...response.data);
+  }
+
+  return data;
+}

--- a/apps/frontend/src/utils/dates.test.ts
+++ b/apps/frontend/src/utils/dates.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from "bun:test";
+
+import { toDateStringInTimeZone } from "./dates";
+
+test("uses the configured timezone when deriving a date-only value", () => {
+  const utcInstant = new Date("2026-07-26T15:00:00Z");
+
+  expect(toDateStringInTimeZone(utcInstant, "Asia/Tokyo")).toBe("2026-07-27");
+});

--- a/apps/frontend/src/utils/dates.ts
+++ b/apps/frontend/src/utils/dates.ts
@@ -32,6 +32,22 @@ export function toDateString(date: Date | string | undefined): string | undefine
   return `${date.getFullYear()}-${month}-${day}`;
 }
 
+export function toDateStringInTimeZone(date: Date, timeZone: string): string {
+  const parts = new Intl.DateTimeFormat("en", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(date);
+  const values = Object.fromEntries(
+    parts
+      .filter((part) => part.type !== "literal")
+      .map((part) => [part.type, part.value]),
+  );
+
+  return `${values.year}-${values.month}-${values.day}`;
+}
+
 export function toDate(dateString: string | undefined | null): Date | undefined {
   if (!dateString) return undefined;
   const [year, month, day] = dateString.split("-").map(Number);

--- a/apps/frontend/src/utils/export-table-server.test.ts
+++ b/apps/frontend/src/utils/export-table-server.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+
+import { createTableExportResponse } from "./export-table-server";
+
+const table = {
+  headers: ["ID", "Title"],
+  rows: [["1", 'A, "quoted" title']],
+};
+
+describe("createTableExportResponse", () => {
+  test("creates tab-separated text for clipboard copy", async () => {
+    const response = createTableExportResponse(table, "records", "copy");
+
+    expect(response.headers.get("Content-Type")).toBe("text/plain; charset=utf-8");
+    expect(await response.text()).toBe('ID\tTitle\n1\tA, "quoted" title');
+  });
+
+  test("creates an escaped CSV attachment", async () => {
+    const response = createTableExportResponse(table, "records", "csv");
+
+    expect(response.headers.get("Content-Disposition")).toBe('attachment; filename="records.csv"');
+    expect(await response.text()).toBe('ID,Title\n1,"A, ""quoted"" title"');
+  });
+
+  test("creates a non-empty Excel attachment", async () => {
+    const response = createTableExportResponse(table, "records", "excel");
+
+    expect(response.headers.get("Content-Disposition")).toBe('attachment; filename="records.xlsx"');
+    expect((await response.arrayBuffer()).byteLength).toBeGreaterThan(0);
+  });
+});

--- a/apps/frontend/src/utils/export-table-server.ts
+++ b/apps/frontend/src/utils/export-table-server.ts
@@ -1,0 +1,52 @@
+import { utils, write } from "xlsx";
+
+export type TableExportData = {
+  headers: string[];
+  rows: string[][];
+};
+
+export type TableExportFormat = "copy" | "csv" | "excel";
+
+function toDelimitedText({ headers, rows }: TableExportData, delimiter: "," | "\t") {
+  const escapeCsvValue = (value: string) => {
+    if (/[,\n]/.test(value)) return `"${value.replace(/"/g, '""')}"`;
+    return value;
+  };
+
+  const formatRow = (row: string[]) =>
+    row.map((value) => (delimiter === "," ? escapeCsvValue(value) : value)).join(delimiter);
+
+  return [headers, ...rows].map(formatRow).join("\n");
+}
+
+export function createTableExportResponse(
+  data: TableExportData,
+  filename: string,
+  format: TableExportFormat,
+) {
+  if (format === "copy") {
+    return new Response(toDelimitedText(data, "\t"), {
+      headers: { "Content-Type": "text/plain; charset=utf-8" },
+    });
+  }
+
+  if (format === "csv") {
+    return new Response(toDelimitedText(data, ","), {
+      headers: {
+        "Content-Type": "text/csv; charset=utf-8",
+        "Content-Disposition": `attachment; filename="${filename}.csv"`,
+      },
+    });
+  }
+
+  const worksheet = utils.aoa_to_sheet([data.headers, ...data.rows]);
+  const workbook = utils.book_new();
+  utils.book_append_sheet(workbook, worksheet, "Sheet1");
+
+  return new Response(write(workbook, { bookType: "xlsx", type: "buffer" }), {
+    headers: {
+      "Content-Type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      "Content-Disposition": `attachment; filename="${filename}.xlsx"`,
+    },
+  });
+}

--- a/apps/frontend/src/utils/export-table.ts
+++ b/apps/frontend/src/utils/export-table.ts
@@ -1,38 +1,26 @@
-import { utils, writeFile } from "xlsx";
-
-export type TableExportData = {
-  headers: string[];
-  rows: string[][];
-};
-
-export function copyTableData({ headers, rows }: TableExportData): void {
-  const lines = [headers, ...rows].map((row) => row.join("\t")).join("\n");
-  navigator.clipboard.writeText(lines);
+async function throwForFailedExport(response: Response) {
+  if (response.ok) return;
+  throw new Error((await response.text()) || "Failed to export table data.");
 }
 
-export function downloadCsv({ headers, rows }: TableExportData, filename: string): void {
-  const escapeSpecialChars = (value: string) => {
-    if (/[,"\n]/.test(value)) {
-      return `"${value.replace(/"/g, '""')}"`;
-    }
-    return value;
-  };
+export async function copyExportResponse(response: Response): Promise<void> {
+  await throwForFailedExport(response);
+  await navigator.clipboard.writeText(await response.text());
+}
 
-  const lines = [headers, ...rows].map((row) => row.map(escapeSpecialChars).join(",")).join("\n");
+export async function downloadExportResponse(response: Response): Promise<void> {
+  await throwForFailedExport(response);
 
-  const blob = new Blob([lines], { type: "text/csv;charset=utf-8;" });
+  const blob = await response.blob();
+  const filename = response.headers.get("Content-Disposition")?.match(/filename="([^"]+)"/)?.[1];
+  if (!filename) throw new Error("Export response did not include a filename.");
+
+  const url = URL.createObjectURL(blob);
   const link = document.createElement("a");
-  link.href = URL.createObjectURL(blob);
-  link.download = `${filename}.csv`;
-  document.body.appendChild(link);
+  link.href = url;
+  link.download = filename;
+  document.body.append(link);
   link.click();
-  document.body.removeChild(link);
-  URL.revokeObjectURL(link.href);
-}
-
-export function downloadExcel({ headers, rows }: TableExportData, filename: string): void {
-  const worksheet = utils.aoa_to_sheet([headers, ...rows]);
-  const workbook = utils.book_new();
-  utils.book_append_sheet(workbook, worksheet, "Sheet1");
-  writeFile(workbook, `${filename}.xlsx`);
+  link.remove();
+  URL.revokeObjectURL(url);
 }


### PR DESCRIPTION
- News の公開日付バグ修正
- Alerts の日付バグ修正
- Front Pageの統計情報を非表示
- /research, /dataset のページの CSV, Excel, Copy ボタンの全件をダウンロードされるように修正　（フロント側対応）
- /research, /dataset のページネーションテーブルに任意のページに飛ぶようの機能を追加
- /research, /dataset のテーブルの高さ制限をなくしました
- research 詳細ページの表示修正（サブタイトルだけがカラムに残らないように）
- research projectに URL がないとき、 `URL`　を表示しない　（何も表示しない） 

** Deploy **
特に migrationやpackage の変更がないので、今テーナ再構築せずにdeplyできます。