### PR TITLE
Penqe/work

### DIFF
--- a/apps/frontend/localization/messages/en.json
+++ b/apps/frontend/localization/messages/en.json
@@ -188,6 +188,8 @@
     "humId": "Research ID",
     "datasets": "Datasets",
     "release-info": "Release info",
+    "to-latest-version": "To the latest version",
+    "latest-version": "Latest",
     "researchOverview": "Research overview",
     "aims": "Aims",
     "title": "Title",

--- a/apps/frontend/localization/messages/en.json
+++ b/apps/frontend/localization/messages/en.json
@@ -187,6 +187,8 @@
     "research-list": "List of researches",
     "humId": "Research ID",
     "datasets": "Datasets",
+    "datasetsAddedInRelease": "Datasets added in this release",
+    "noDatasetsAddedInRelease": "No datasets added in this release.",
     "release-info": "Release info",
     "to-latest-version": "To the latest version",
     "latest-version": "Latest",

--- a/apps/frontend/localization/messages/ja.json
+++ b/apps/frontend/localization/messages/ja.json
@@ -188,6 +188,8 @@
     "research-list": "研究一覧",
     "humId": "研究 ID",
     "datasets": "データセット一覧",
+    "datasetsAddedInRelease": "このリリースで追加されたデータセット",
+    "noDatasetsAddedInRelease": "このリリースで追加されたデータセットはありません。",
     "release-info": "リリース情報",
     "to-latest-version": "最新バージョンへ",
     "latest-version": "最新",

--- a/apps/frontend/localization/messages/ja.json
+++ b/apps/frontend/localization/messages/ja.json
@@ -151,7 +151,7 @@
     "research-version": "研究ID",
     "research": "研究",
     "version": "バージョン",
-    "releaseDate": "公開日付",
+    "releaseDate": "公開日",
     "versionReleaseDate": "更新日付",
     "dateModified": "更新日",
     "parentJgaStudyId": "JGA Study ID",
@@ -238,7 +238,7 @@
     "alreadyInCart": "カートに追加済み",
     "addToCart": "カートに追加",
     "info": "情報",
-    "releaseDate": "公開日付",
+    "releaseDate": "公開日",
     "typeOfData": "データの種類",
     "criteria": "アクセス制限",
     "experiments": "解析手法"

--- a/apps/frontend/localization/messages/ja.json
+++ b/apps/frontend/localization/messages/ja.json
@@ -189,6 +189,8 @@
     "humId": "研究 ID",
     "datasets": "データセット一覧",
     "release-info": "リリース情報",
+    "to-latest-version": "最新バージョンへ",
+    "latest-version": "最新",
     "researchOverview": "研究概要",
     "aims": "目的",
     "title": "研究題目",

--- a/apps/frontend/src/components/DatasetLink.tsx
+++ b/apps/frontend/src/components/DatasetLink.tsx
@@ -6,9 +6,9 @@ import { TextWithIcon } from "./TextWithIcon";
 /**
  * Link to a dataset with icon
  */
-export function DatasetLink({ datasetId }: { datasetId: string }) {
+export function DatasetLink({ datasetId, className }: { datasetId: string; className?: string }) {
   return (
-    <Link to="/{-$lang}/dataset/$datasetId" params={{ datasetId }}>
+    <Link className={className} to="/{-$lang}/dataset/$datasetId" params={{ datasetId }}>
       <TextWithIcon icon={FA_ICONS.dataset}>{datasetId}</TextWithIcon>
     </Link>
   );

--- a/apps/frontend/src/components/Pagination.tsx
+++ b/apps/frontend/src/components/Pagination.tsx
@@ -201,7 +201,7 @@ export function Pagination({ pagination, onItemsPerPageChange, className }: Pagi
               </label>
               <Input
                 aria-label={t("pageNumber")}
-                className="w-16 text-center"
+                className="w-24 text-center"
                 id="pagination-page"
                 max={pagination.totalPages}
                 min="1"

--- a/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/research/$humId/$version.tsx
+++ b/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/research/$humId/$version.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, isNotFound, notFound } from "@tanstack/react-router";
 
 import { NotFound } from "@/components/NotFound";
+import { i18n } from "@/config/i18n";
 import {
   getExternalDatasetIds,
   prefetchDatasetParentResearches,
@@ -37,6 +38,19 @@ export const Route = createFileRoute("/{-$lang}/_layout/_main/_other/research/$h
 
   notFoundComponent: () => <NotFound />,
   component: RouteComponent,
+  head: ({ loaderData, match }) => {
+    const lang = match.context.lang;
+
+    const seoTitle = `HumanDBs - ${loaderData?.data.title[lang ?? i18n.defaultLocale] ?? match.context.messages?.common?.research} (${loaderData?.data.version ?? ""})`;
+
+    return {
+      meta: [
+        {
+          title: seoTitle,
+        },
+      ],
+    };
+  },
 });
 
 function RouteComponent() {

--- a/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/research/$humId/-VersionCard.tsx
+++ b/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/research/$humId/-VersionCard.tsx
@@ -1,5 +1,6 @@
 import { ClientOnly, useRouteContext } from "@tanstack/react-router";
 import { createColumnHelper } from "@tanstack/react-table";
+import { LucideExternalLink } from "lucide-react";
 import { useTranslations } from "use-intl";
 
 import { useMemo } from "react";
@@ -79,6 +80,7 @@ export function VersionCard({
                   className="text-white no-underline visited:text-white"
                   to="/{-$lang}/research/$humId"
                 >
+                  <LucideExternalLink className="mr-2 inline size-5" />
                   {`${t("Research.to-latest-version")} (${versionData.latestVersion})`}
                 </Link>
               </Badge>

--- a/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/research/$humId/-VersionCard.tsx
+++ b/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/research/$humId/-VersionCard.tsx
@@ -20,6 +20,7 @@ import { ResearchDatasetCartRowButton } from "@/components/ResearchDatasetCartRo
 import { ResearchLink } from "@/components/ResearchLink";
 import { Separator } from "@/components/Separator";
 import { SortHeader, Table } from "@/components/Table";
+import { Badge } from "@/components/ui/badge";
 import type { Locale } from "@/config/i18n";
 import { i18n } from "@/config/i18n";
 import { useCartTableHeader } from "@/hooks/useCart";
@@ -49,6 +50,8 @@ export function VersionCard({
     t,
   };
 
+  const isLatestVersion = versionData.version === versionData.latestVersion;
+
   return (
     <CardWithCaption
       size={"lg"}
@@ -65,6 +68,21 @@ export function VersionCard({
             >
               {t("Research.release-info")}
             </Link>
+          }
+          right={
+            isLatestVersion ? (
+              <Badge className="text-sm">{t("Research.latest-version")}</Badge>
+            ) : (
+              <Badge>
+                <Link
+                  target="_blank"
+                  className="text-white no-underline visited:text-white"
+                  to="/{-$lang}/research/$humId"
+                >
+                  {`${t("Research.to-latest-version")} (${versionData.latestVersion})`}
+                </Link>
+              </Badge>
+            )
           }
         >
           {versionData.humVersionId}

--- a/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/research/$humId/-releaseDatasets.test.ts
+++ b/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/research/$humId/-releaseDatasets.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+
+import { getAddedDatasets } from "./-releaseDatasets";
+
+describe("getAddedDatasets", () => {
+  test("uses the oldest release as the baseline", () => {
+    const datasets = [{ datasetId: "JGAD000001" }, { datasetId: "JGAD000002" }];
+
+    expect(getAddedDatasets(datasets)).toEqual(datasets);
+  });
+
+  test("returns only dataset IDs absent from the preceding release", () => {
+    const previousDatasets = [{ datasetId: "JGAD000001" }, { datasetId: "JGAD000002" }];
+    const currentDatasets = [
+      { datasetId: "JGAD000001" },
+      { datasetId: "JGAD000002" },
+      { datasetId: "JGAD000003" },
+    ];
+
+    expect(getAddedDatasets(currentDatasets, previousDatasets)).toEqual([
+      { datasetId: "JGAD000003" },
+    ]);
+  });
+
+  test("returns no datasets when a release adds none", () => {
+    const datasets = [{ datasetId: "JGAD000001" }];
+
+    expect(getAddedDatasets(datasets, datasets)).toEqual([]);
+  });
+});

--- a/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/research/$humId/-releaseDatasets.ts
+++ b/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/research/$humId/-releaseDatasets.ts
@@ -1,0 +1,15 @@
+type DatasetReference = { datasetId: string };
+
+/**
+ * Returns the datasets introduced by a release. The first (oldest) release
+ * has no predecessor, so its full dataset list establishes the baseline.
+ */
+export function getAddedDatasets<T extends DatasetReference>(
+  currentDatasets: T[],
+  previousDatasets?: readonly DatasetReference[],
+): T[] {
+  if (!previousDatasets) return currentDatasets;
+
+  const previousDatasetIds = new Set(previousDatasets.map(({ datasetId }) => datasetId));
+  return currentDatasets.filter(({ datasetId }) => !previousDatasetIds.has(datasetId));
+}

--- a/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/research/$humId/versions.tsx
+++ b/apps/frontend/src/routes/{-$lang}/_layout/_main/_other/research/$humId/versions.tsx
@@ -11,6 +11,8 @@ import { FA_ICONS } from "@/lib/faIcons";
 import { getResearchVersionsQueryOptions } from "@/serverFunctions/researches";
 import type { RenderedResearchVersionItem } from "@/utils/renderedHtml/types";
 
+import { getAddedDatasets } from "./-releaseDatasets";
+
 export const Route = createFileRoute("/{-$lang}/_layout/_main/_other/research/$humId/versions")({
   component: RouteComponent,
   loader: async ({ context, params }) => {
@@ -40,9 +42,12 @@ function RouteComponent() {
       }
     >
       <ul className="space-y-4">
-        {data.map((ver, i) => (
+        {data.map((ver, index) => (
           <li key={ver.humVersionId}>
-            <VersionInfo version={ver} />
+            <VersionInfo
+              version={ver}
+              addedDatasets={getAddedDatasets(ver.datasets, data[index + 1]?.datasets)}
+            />
           </li>
         ))}
       </ul>
@@ -50,7 +55,13 @@ function RouteComponent() {
   );
 }
 
-function VersionInfo({ version }: { version: RenderedResearchVersionItem }) {
+function VersionInfo({
+  version,
+  addedDatasets,
+}: {
+  version: RenderedResearchVersionItem;
+  addedDatasets: RenderedResearchVersionItem["datasets"];
+}) {
   const { lang } = useRouteContext({ strict: false });
   const tResearch = useTranslations("Research");
 
@@ -64,15 +75,24 @@ function VersionInfo({ version }: { version: RenderedResearchVersionItem }) {
         </Route.Link>
       </h3>
       <section className="flex items-start gap-5 px-3 py-4 text-sm">
-        <div>
-          <h4 className="mb-4 font-semibold text-secondary text-xs">{tResearch("datasets")}</h4>
-          <ul className="w-72 space-y-1.5">
-            {version.datasets.map((ds) => (
-              <li key={ds.datasetId}>
-                <DatasetLink datasetId={ds.datasetId} />
-              </li>
-            ))}
-          </ul>
+        <div className="w-80 shrink-0">
+          <h4 className="mb-4 font-semibold text-secondary text-xs">
+            {tResearch("datasetsAddedInRelease")}
+          </h4>
+          {addedDatasets.length > 0 ? (
+            <ul className="w-full space-y-1.5">
+              {addedDatasets.map((ds) => (
+                <li key={ds.datasetId}>
+                  <DatasetLink
+                    className="max-w-full whitespace-normal [&>span>span]:min-w-0 [&>span>span]:break-all"
+                    datasetId={ds.datasetId}
+                  />
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-gray-400 text-sm">{tResearch("noDatasetsAddedInRelease")}</p>
+          )}
         </div>
         <div>
           <h4 className="mb-4 font-semibold text-secondary text-xs">{tResearch("releaseNote")}</h4>


### PR DESCRIPTION
- UI修正
- Research詳細ページに最新バージョンへのリンクを追加
- リリース情報に、追加されたDatasetリストのみを表示（全部ではなく）
- 以前Researchバージョンのページに SEO用の title を追加
- "公開日付" -> "公開日"